### PR TITLE
Example: Docker daemon API usage to manage dockers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82e7850583ead5f8bbef247e2a3c37a19bd576e8420cd262a6711921827e1e5"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite 0.2.9",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.42.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+dependencies = [
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1157,41 @@ dependencies = [
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2228,6 +2301,25 @@ dependencies = [
  "tokio",
  "tokio-rustls",
 ]
+
+[[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4801,6 +4893,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "resource-client"
+version = "0.1.0"
+dependencies = [
+ "bollard",
+ "futures-util",
+ "tokio",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6073,6 +6174,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.2",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7330,9 +7465,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
  "autocfg",
  "bytes",

--- a/crates/resource-client/Cargo.toml
+++ b/crates/resource-client/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "resource-client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bollard = "0.13"
+futures-util = "0.3"
+tokio = { version = "1.21", features = ["full"] }

--- a/crates/resource-client/src/main.rs
+++ b/crates/resource-client/src/main.rs
@@ -1,0 +1,75 @@
+//! This example will run a non-interactive command inside the container using `docker exec`
+
+use bollard::container::{Config, RemoveContainerOptions};
+use bollard::Docker;
+
+use bollard::container::StatsOptions;
+use bollard::exec::{CreateExecOptions, StartExecResults};
+use bollard::image::CreateImageOptions;
+use futures_util::stream::StreamExt;
+use futures_util::TryStreamExt;
+
+const IMAGE: &str = "alpine:3";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let docker = Docker::connect_with_socket_defaults().unwrap();
+
+    docker
+        .create_image(
+            Some(CreateImageOptions {
+                from_image: IMAGE,
+                ..Default::default()
+            }),
+            None,
+            None,
+        )
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let alpine_config = Config {
+        image: Some(IMAGE),
+        tty: Some(true),
+        ..Default::default()
+    };
+
+    let id = docker
+        .create_container::<&str, &str>(None, alpine_config)
+        .await?
+        .id;
+    docker.start_container::<String>(&id, None).await?;
+
+    println!("===================== Command execution =====================");
+    // non interactive
+    let exec = docker
+        .create_exec(
+            &id,
+            CreateExecOptions {
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                cmd: Some(vec!["ls", "-l", "/"]),
+                ..Default::default()
+            },
+        )
+        .await?
+        .id;
+    if let StartExecResults::Attached { mut output, .. } = docker.start_exec(&exec, None).await? {
+        while let Some(Ok(msg)) = output.next().await {
+            print!("{}", msg);
+        }
+    } else {
+        unreachable!();
+    }
+
+    docker
+        .remove_container(
+            &id,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
There are available clients that use docker daemon API. 

Found the following common libraries in Rust:
- [Bollard](https://github.com/fussybeaver/bollard)
- [Dockworker](https://github.com/Idein/dockworker)

Tried simple example at this PR. Looks working. 

@eldargab @mo4islona @dzhelezov @ozgrakkurt @tmcgroul 