### PR TITLE
Migrate chunks from S3 to HTTP API in proto schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsquid-messages"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subsquid-messages"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [features]

--- a/messages/proto/messages.proto
+++ b/messages/proto/messages.proto
@@ -65,13 +65,27 @@ message Ping {
   bytes signature = 5;
 }
 
+message HttpHeader {
+  string name = 1;
+  string value = 2;
+}
+
+message AssignedChunk {
+  string path = 1;  // "0000000000/0000808640-0000816499-b0486318"
+  repeated uint32 filenames = 2;  // index in known_filenames array
+}
+
 message DatasetChunks {
-  string dataset_url = 1;
-  repeated string chunks = 2;
+  string dataset_id = 1;  // "s3://moonbeam-evm-1"
+  string download_url = 3;  // "https://moonbeam-evm-1.sqd-datasets.io/"
+  repeated string chunks_legacy = 2 [deprecated = true];  // used in workers <=0.4.0
+  repeated AssignedChunk chunks = 4;
 }
 
 message WorkerAssignment {
   repeated DatasetChunks dataset_chunks = 1;
+  repeated HttpHeader http_headers = 2;
+  repeated string known_filenames = 3;  // "blocks.parquet"
 }
 
 message Pong {


### PR DESCRIPTION
See #100
This approach would only increase the message size by about 30% (32k -> 42k). Without using a dict encoding it would increase it 4 times (123k).