### PR TITLE
Adapt protobufs for the new gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "subsquid-messages"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/messages/Cargo.toml
+++ b/messages/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subsquid-messages"
 license = "AGPL-3.0-or-later"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2021"
 
 [features]

--- a/messages/proto/messages.proto
+++ b/messages/proto/messages.proto
@@ -99,6 +99,7 @@ message QueryResult {
 message OkResult {
   bytes data = 1;
   optional bytes exec_plan = 2;
+  optional uint64 last_block = 3;
 }
 
 message QuerySubmitted {

--- a/messages/proto/messages.proto
+++ b/messages/proto/messages.proto
@@ -83,6 +83,9 @@ message Query {// Optional fields enforce serializing default values
   optional bool profiling = 4;
   optional string client_state_json = 5;
   bytes signature = 6;
+  // If present, these values should be used instead of the ones in the query contents
+  optional uint64 from_block = 7;
+  optional uint64 to_block = 8;
 }
 
 message QueryResult {


### PR DESCRIPTION
- Return `last_block` with the query result
- Add block range to the query

Both changes only affect the gateway performance, not the functionality. However, it's better to include it sooner than later to start working on the final gateway implementation.