### PR TITLE
Reliable clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-network-transport"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqd-network-transport"
 license = "AGPL-3.0-or-later"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/transport/src/actors/logs_collector.rs
+++ b/crates/transport/src/actors/logs_collector.rs
@@ -119,7 +119,7 @@ pub struct LogsCollectorBehaviour {
 
 impl LogsCollectorBehaviour {
     pub fn new(mut base: BaseBehaviour) -> Self {
-        base.keep_all_connections_alive();
+        base.maintain_worker_connections();
         Self { base: base.into() }
     }
 }

--- a/crates/transport/src/actors/pings_collector.rs
+++ b/crates/transport/src/actors/pings_collector.rs
@@ -52,7 +52,7 @@ pub struct PingsCollectorBehaviour {
 
 impl PingsCollectorBehaviour {
     pub fn new(mut base: BaseBehaviour, _config: PingsCollectorConfig) -> Wrapped<Self> {
-        base.keep_all_connections_alive();
+        base.maintain_worker_connections();
         Self { base: base.into() }.into()
     }
 }

--- a/crates/transport/src/actors/portal.rs
+++ b/crates/transport/src/actors/portal.rs
@@ -282,7 +282,7 @@ pub struct PortalBehaviour {
 
 impl PortalBehaviour {
     pub fn new(mut base: BaseBehaviour, _config: PortalConfig) -> Wrapped<Self> {
-        base.keep_all_connections_alive();
+        base.maintain_worker_connections();
         Self {
             base: base.into(),
             provider_query: Default::default(),

--- a/crates/transport/src/actors/portal.rs
+++ b/crates/transport/src/actors/portal.rs
@@ -242,6 +242,11 @@ impl PortalTransportHandle {
         }
     }
 
+    #[cfg(feature = "metrics")]
+    pub fn active_connections(&self) -> u32 {
+        crate::metrics::ACTIVE_CONNECTIONS.get()
+    }
+
     pub async fn send_logs(&self, logs: Vec<QueryFinished>) {
         let listeners = self.log_listeners.lock().clone();
         self.publish_portal_logs(logs, &listeners).await;

--- a/crates/transport/src/actors/sql_client.rs
+++ b/crates/transport/src/actors/sql_client.rs
@@ -141,7 +141,7 @@ pub struct SQLClientBehaviour {
 
 impl SQLClientBehaviour {
     pub fn new(mut base: BaseBehaviour) -> Wrapped<Self> {
-        base.keep_all_connections_alive();
+        base.maintain_worker_connections();
         Self {
             inner: InnerBehaviour { base: base.into() },
         }

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use sqd_contract_client::{Client as ContractClient, NetworkNodes};
 
 #[cfg(feature = "metrics")]
-use crate::metrics::{ACTIVE_CONNECTIONS, ONGOING_QUERIES};
+use crate::metrics::{ACTIVE_CONNECTIONS, ONGOING_LOOKUPS};
 use crate::{
     behaviour::{
         addr_cache::AddressCache,
@@ -109,7 +109,7 @@ pub struct BaseBehaviour {
     inner: InnerBehaviour,
     keypair: Keypair,
     pending_events: VecDeque<TToSwarm<Self>>,
-    ongoing_queries: BiHashMap<PeerId, QueryId>,
+    ongoing_lookups: BiHashMap<PeerId, QueryId>,
     outbound_conns: HashMap<PeerId, u32>,
     registered_workers: Arc<RwLock<HashSet<PeerId>>>,
     whitelist_initialized: bool,
@@ -181,7 +181,7 @@ impl BaseBehaviour {
             inner,
             keypair: keypair.clone(),
             pending_events: Default::default(),
-            ongoing_queries: Default::default(),
+            ongoing_lookups: Default::default(),
             outbound_conns: Default::default(),
             registered_workers: Arc::new(RwLock::new(Default::default())),
             whitelist_initialized: false,
@@ -216,14 +216,14 @@ impl BaseBehaviour {
     }
 
     pub fn find_and_dial(&mut self, peer_id: PeerId) {
-        if self.ongoing_queries.contains_left(&peer_id) {
+        if self.ongoing_lookups.contains_left(&peer_id) {
             log::debug!("Query for peer {peer_id} already ongoing");
         } else {
             log::debug!("Starting query for peer {peer_id}");
             let query_id = self.inner.kademlia.get_closest_peers(peer_id);
-            self.ongoing_queries.insert(peer_id, query_id);
+            self.ongoing_lookups.insert(peer_id, query_id);
             #[cfg(feature = "metrics")]
-            ONGOING_QUERIES.inc();
+            ONGOING_LOOKUPS.inc();
         }
     }
 
@@ -425,7 +425,7 @@ impl BaseBehaviour {
             return None;
         };
 
-        let peer_id = self.ongoing_queries.get_by_right(&query_id)?.to_owned();
+        let peer_id = self.ongoing_lookups.get_by_right(&query_id)?.to_owned();
         let peer_info = match result {
             Ok(GetClosestPeersOk { peers, .. })
             | Err(GetClosestPeersError::Timeout { peers, .. }) => {
@@ -437,9 +437,9 @@ impl BaseBehaviour {
         // Query finished
         if query_finished {
             log::debug!("Query for peer {peer_id} finished.");
-            self.ongoing_queries.remove_by_right(&query_id);
+            self.ongoing_lookups.remove_by_right(&query_id);
             #[cfg(feature = "metrics")]
-            ONGOING_QUERIES.dec();
+            ONGOING_LOOKUPS.dec();
         }
 
         if let Some(peer_info) = peer_info {

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -309,6 +309,8 @@ impl BehaviourWrapper for BaseBehaviour {
                 break;
             };
             if !self.outbound_conn_exists(&peer_id) {
+                // find_and_dial inserts into ongoing_lookups only for actual DHT queries;
+                // cached-address dials don't count toward the max_concurrent_lookups cap.
                 self.find_and_dial(peer_id);
             }
         }

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     num::NonZeroUsize,
-    sync::Arc,
     task::{Context, Poll},
     time::Duration,
     vec,
@@ -26,7 +25,6 @@ use libp2p::{
     StreamProtocol,
 };
 use libp2p_swarm_derive::NetworkBehaviour;
-use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
 use sqd_contract_client::{Client as ContractClient, NetworkNodes};
@@ -49,7 +47,7 @@ use crate::{
 #[cfg(feature = "pubsub")]
 use crate::{protocol::MAX_PUBSUB_MSG_SIZE, PubsubBehaviour, PubsubMsg};
 
-use super::stream_client::{self, ClientBehaviour, ClientConfig, StreamClientHandle};
+use super::stream_client::{ClientBehaviour, ClientConfig, StreamClientHandle};
 
 #[derive(NetworkBehaviour)]
 pub struct InnerBehaviour {
@@ -80,6 +78,8 @@ pub struct BaseConfig {
     pub max_pubsub_msg_size: usize,
     /// Maximum number of peers to keep in the address cache (default: 1024)
     pub addr_cache_size: NonZeroUsize,
+    /// Maximum number of concurrent Kademlia lookups for worker discovery (default: 20)
+    pub max_concurrent_lookups: usize,
 }
 
 impl BaseConfig {
@@ -93,6 +93,7 @@ impl BaseConfig {
         let max_pubsub_msg_size = parse_env_var("MAX_PUBSUB_MSG_SIZE", MAX_PUBSUB_MSG_SIZE);
         let addr_cache_size = NonZeroUsize::new(parse_env_var("ADDR_CACHE_SIZE", 1024))
             .expect("addr_cache_size should be > 0");
+        let max_concurrent_lookups = parse_env_var("MAX_CONCURRENT_LOOKUPS", 20);
         Self {
             onchain_update_interval,
             autonat_timeout,
@@ -101,6 +102,7 @@ impl BaseConfig {
             #[cfg(feature = "pubsub")]
             max_pubsub_msg_size,
             addr_cache_size,
+            max_concurrent_lookups,
         }
     }
 }
@@ -111,11 +113,14 @@ pub struct BaseBehaviour {
     pending_events: VecDeque<TToSwarm<Self>>,
     ongoing_lookups: BiHashMap<PeerId, QueryId>,
     outbound_conns: HashMap<PeerId, u32>,
-    registered_workers: Arc<RwLock<HashSet<PeerId>>>,
+    registered_workers: HashSet<PeerId>,
     whitelist_initialized: bool,
     identified_peers: HashSet<PeerId>,
     /// Last confidence value sent, in tenths (0–10). None means nothing sent yet.
     last_sent_confidence_step: Option<u8>,
+    maintain_worker_connections: bool,
+    pending_lookups: VecDeque<PeerId>,
+    max_concurrent_lookups: usize,
 }
 
 #[allow(dead_code)]
@@ -183,10 +188,13 @@ impl BaseBehaviour {
             pending_events: Default::default(),
             ongoing_lookups: Default::default(),
             outbound_conns: Default::default(),
-            registered_workers: Arc::new(RwLock::new(Default::default())),
+            registered_workers: Default::default(),
             whitelist_initialized: false,
             identified_peers: HashSet::new(),
             last_sent_confidence_step: None,
+            maintain_worker_connections: false,
+            pending_lookups: Default::default(),
+            max_concurrent_lookups: config.max_concurrent_lookups,
         }
     }
 
@@ -199,8 +207,9 @@ impl BaseBehaviour {
         self.inner.kademlia.set_mode(Some(kad::Mode::Server));
     }
 
-    pub fn keep_all_connections_alive(&mut self) {
+    pub fn maintain_worker_connections(&mut self) {
         self.inner.keep_alive.keep_all_connections_alive();
+        self.maintain_worker_connections = true;
     }
 
     pub fn request_handle(
@@ -229,10 +238,6 @@ impl BaseBehaviour {
 
     pub fn outbound_conn_exists(&self, peer_id: &PeerId) -> bool {
         self.outbound_conns.get(peer_id).is_some_and(|x| *x > 0)
-    }
-
-    pub fn can_be_dialed(&self, peer_id: &PeerId) -> bool {
-        self.outbound_conn_exists(peer_id) || self.inner.address_cache.contains(peer_id)
     }
 
     pub fn allow_peer(&mut self, peer_id: PeerId) {
@@ -286,7 +291,6 @@ impl BehaviourWrapper for BaseBehaviour {
                 None
             }
             InnerBehaviourEvent::Whitelist(nodes) => self.on_nodes_update(nodes),
-            InnerBehaviourEvent::Stream(ev) => self.on_stream_event(ev),
             _ => None,
         }
     }
@@ -294,6 +298,15 @@ impl BehaviourWrapper for BaseBehaviour {
     fn poll(&mut self, _cx: &mut Context<'_>) -> Poll<impl IntoIterator<Item = TToSwarm<Self>>> {
         if let Some(ev) = self.pending_events.pop_front() {
             return Poll::Ready(Some(ev));
+        }
+
+        while self.ongoing_lookups.len() < self.max_concurrent_lookups {
+            let Some(peer_id) = self.pending_lookups.pop_front() else {
+                break;
+            };
+            if !self.outbound_conn_exists(&peer_id) {
+                self.find_and_dial(peer_id);
+            }
         }
 
         Poll::Pending
@@ -324,6 +337,13 @@ impl BaseBehaviour {
         match self.outbound_conns.get_mut(&peer_id) {
             Some(x) => *x -= 1,
             None => log::error!("Closed connection not established before"),
+        }
+        if self.maintain_worker_connections
+            && !self.outbound_conn_exists(&peer_id)
+            && self.registered_workers.contains(&peer_id)
+        {
+            log::debug!("Worker {peer_id} disconnected, scheduling reconnection");
+            self.pending_lookups.push_back(peer_id);
         }
         None
     }
@@ -479,24 +499,9 @@ impl BaseBehaviour {
         None
     }
 
-    // TODO: consider capturing all dial requests, not only from the stream behaviour
-    fn on_stream_event(&mut self, ev: stream_client::Event) -> Option<TToSwarm<Self>> {
-        // When trying to dial an unknown peer, try to find it on DHT first
-        let stream_client::Event::Dial(opts) = ev;
-        match opts.get_peer_id() {
-            Some(peer_id) if !self.can_be_dialed(&peer_id) => {
-                // The ConnectionId will not correspond to the requested one,
-                // but it's not used by the stream behaviour anyway
-                self.find_and_dial(peer_id);
-                None
-            }
-            _ => Some(ToSwarm::Dial { opts }),
-        }
-    }
-
     fn on_nodes_update(&mut self, nodes: NetworkNodes) -> Option<TToSwarm<Self>> {
         log::debug!("Updating registered workers");
-        *self.registered_workers.write() = nodes.workers;
+        self.registered_workers = nodes.workers;
 
         if !self.whitelist_initialized {
             self.whitelist_initialized = true;
@@ -508,6 +513,14 @@ impl BaseBehaviour {
                 log::debug!("Whitelist initialized, running Kademlia bootstrap");
                 if let Err(kad::NoKnownPeers()) = self.get_kademlia_mut().bootstrap() {
                     log::warn!("Failed to trigger bootstrap: no known peers");
+                }
+            }
+        }
+
+        if self.maintain_worker_connections {
+            for peer_id in &self.registered_workers {
+                if !self.outbound_conn_exists(peer_id) {
+                    self.pending_lookups.push_back(*peer_id);
                 }
             }
         }

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -225,7 +225,11 @@ impl BaseBehaviour {
     }
 
     pub fn find_and_dial(&mut self, peer_id: PeerId) {
-        if self.ongoing_lookups.contains_left(&peer_id) {
+        if self.inner.address_cache.contains(&peer_id) {
+            log::debug!("Dialing peer {peer_id} using cached address");
+            self.pending_events
+                .push_back(ToSwarm::Dial { opts: peer_id.into() });
+        } else if self.ongoing_lookups.contains_left(&peer_id) {
             log::debug!("Query for peer {peer_id} already ongoing");
         } else {
             log::debug!("Starting query for peer {peer_id}");

--- a/crates/transport/src/behaviour/stream_client.rs
+++ b/crates/transport/src/behaviour/stream_client.rs
@@ -1,15 +1,10 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use libp2p::{
-    swarm::{dial_opts::DialOpts, NetworkBehaviour, THandlerInEvent, ToSwarm},
-    PeerId, StreamProtocol,
-};
+use libp2p::{PeerId, StreamProtocol};
 use libp2p_stream::OpenStreamError;
 
 use crate::{util::StreamWithPayload, BehaviourWrapper};
-
-use super::wrapped::TToSwarm;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ClientConfig {
@@ -165,28 +160,12 @@ impl ClientBehaviour {
     }
 }
 
-#[derive(Debug)]
-pub enum Event {
-    Dial(DialOpts),
-}
-
 impl BehaviourWrapper for ClientBehaviour {
-    type Event = Event;
+    type Event = ();
     type Inner = libp2p_stream::Behaviour;
 
     fn inner(&mut self) -> &mut Self::Inner {
         &mut self.inner
-    }
-
-    fn on_inner_command(
-        &mut self,
-        ev: ToSwarm<<Self::Inner as NetworkBehaviour>::ToSwarm, THandlerInEvent<Self::Inner>>,
-    ) -> impl IntoIterator<Item = TToSwarm<Self>> {
-        match ev {
-            // Capture an attempt to dial a peer to be handled by the BaseBehaviour
-            ToSwarm::Dial { opts } => Some(ToSwarm::GenerateEvent(Event::Dial(opts))),
-            e => Some(e.map_out(|()| unreachable!("Stream behaviour doesn't produce events"))),
-        }
     }
 }
 

--- a/crates/transport/src/metrics.rs
+++ b/crates/transport/src/metrics.rs
@@ -10,7 +10,7 @@ use tokio::sync::OnceCell;
 
 lazy_static! {
     pub static ref ACTIVE_CONNECTIONS: Gauge<u32, AtomicU32> = Default::default();
-    pub static ref ONGOING_QUERIES: Gauge<u32, AtomicU32> = Default::default();
+    pub static ref ONGOING_LOOKUPS: Gauge<u32, AtomicU32> = Default::default();
     pub static ref QUEUE_SIZE: Family<Vec<(&'static str, &'static str)>, Gauge<u32, AtomicU32>> =
         Default::default();
     pub static ref DROPPED: Family<Vec<(&'static str, &'static str)>, Counter<u64, AtomicU64>> =
@@ -33,7 +33,7 @@ pub fn register_metrics(registry: &mut Registry) {
     registry.register(
         "ongoing_queries",
         "The number of ongoing kademlia DHT queries",
-        ONGOING_QUERIES.clone(),
+        ONGOING_LOOKUPS.clone(),
     );
     registry.register(
         "queue_size",


### PR DESCRIPTION
Instead of capturing dial attempts and triggering Kademlia lookups (taking multiple seconds), make the clients (portal, pings collector, etc) keep the connections to the workers always open. This way the substream is either opened quickly or fails to open allowing the portal to pick another worker.
This saves query time and also makes the transport more robust by avoiding spamming extra kademlia lookups under the load.