### PR TITLE
Connected event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.key

--- a/crates/transport/src/actors/portal.rs
+++ b/crates/transport/src/actors/portal.rs
@@ -276,6 +276,7 @@ impl PortalBehaviour {
                 stats,
                 step,
             } => self.on_provider_record(id, result, &stats, &step),
+            _ => None,
         }
     }
 

--- a/crates/transport/src/actors/portal_logs_collector.rs
+++ b/crates/transport/src/actors/portal_logs_collector.rs
@@ -70,10 +70,6 @@ pub struct PortalLogsCollectorBehaviour {
 impl PortalLogsCollectorBehaviour {
     pub fn new(mut base: BaseBehaviour) -> Wrapped<Self> {
         base.set_server_mode();
-        let _ = base
-            .get_kademlia_mut()
-            .start_providing(RecordKey::new(PORTAL_LOGS_PROVIDER_KEY));
-        log::info!("Start providing: {:?}", PORTAL_LOGS_PROVIDER_KEY);
         Self {
             inner: InnerBehaviour {
                 base: base.into(),
@@ -94,8 +90,19 @@ impl PortalLogsCollectorBehaviour {
         .into()
     }
 
-    fn on_base_event(&mut self, _ev: BaseBehaviourEvent) -> Option<PortalLogsCollectorEvent> {
-        None
+    fn on_base_event(&mut self, ev: BaseBehaviourEvent) -> Option<PortalLogsCollectorEvent> {
+        match ev {
+            BaseBehaviourEvent::NetworkConnected {  } => {
+                let _ = self
+                    .inner
+                    .base
+                    .get_kademlia_mut()
+                    .start_providing(RecordKey::new(PORTAL_LOGS_PROVIDER_KEY));
+                log::info!("Start providing: {:?}", PORTAL_LOGS_PROVIDER_KEY);
+                None
+            },
+            _ => None
+        }
     }
 
     fn on_collector_v1_request(

--- a/crates/transport/src/actors/portal_logs_collector.rs
+++ b/crates/transport/src/actors/portal_logs_collector.rs
@@ -65,6 +65,7 @@ pub struct InnerBehaviour {
 
 pub struct PortalLogsCollectorBehaviour {
     inner: InnerBehaviour,
+    advertisement_started: bool,
 }
 
 impl PortalLogsCollectorBehaviour {
@@ -86,6 +87,7 @@ impl PortalLogsCollectorBehaviour {
                 )
                 .into(),
             },
+            advertisement_started: false,
         }
         .into()
     }
@@ -93,14 +95,21 @@ impl PortalLogsCollectorBehaviour {
     fn on_base_event(&mut self, ev: BaseBehaviourEvent) -> Option<PortalLogsCollectorEvent> {
         match ev {
             BaseBehaviourEvent::NetworkConnected { confidence } => {
-                log::info!("Network connected with confidence {confidence:.1}");
-                if confidence >= 0.3 {
-                    let _ = self
+                if confidence >= 0.3 && !self.advertisement_started {
+                    let res = self
                         .inner
                         .base
                         .get_kademlia_mut()
                         .start_providing(RecordKey::new(PORTAL_LOGS_PROVIDER_KEY));
-                    log::info!("Start providing: {:?}", PORTAL_LOGS_PROVIDER_KEY);
+                    match res {
+                        Ok(query_id) => {
+                            log::info!("Start providing: {PORTAL_LOGS_PROVIDER_KEY:?} by {query_id:?}");
+                            self.advertisement_started = true;
+                        },
+                        Err(err) => {
+                            log::error!("Advertisement error: {err:?}")
+                        }
+                    }
                 }
                 None
             },

--- a/crates/transport/src/actors/portal_logs_collector.rs
+++ b/crates/transport/src/actors/portal_logs_collector.rs
@@ -92,13 +92,16 @@ impl PortalLogsCollectorBehaviour {
 
     fn on_base_event(&mut self, ev: BaseBehaviourEvent) -> Option<PortalLogsCollectorEvent> {
         match ev {
-            BaseBehaviourEvent::NetworkConnected {  } => {
-                let _ = self
-                    .inner
-                    .base
-                    .get_kademlia_mut()
-                    .start_providing(RecordKey::new(PORTAL_LOGS_PROVIDER_KEY));
-                log::info!("Start providing: {:?}", PORTAL_LOGS_PROVIDER_KEY);
+            BaseBehaviourEvent::NetworkConnected { confidence } => {
+                log::info!("Network connected with confidence {confidence:.1}");
+                if confidence >= 0.3 {
+                    let _ = self
+                        .inner
+                        .base
+                        .get_kademlia_mut()
+                        .start_providing(RecordKey::new(PORTAL_LOGS_PROVIDER_KEY));
+                    log::info!("Start providing: {:?}", PORTAL_LOGS_PROVIDER_KEY);
+                }
                 None
             },
             _ => None

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -335,6 +335,7 @@ impl BaseBehaviour {
         if self.first_identification_received {
             None
         } else {
+            self.first_identification_received = true;
             Some(
                 ToSwarm::GenerateEvent(BaseBehaviourEvent::NetworkConnected {})
             )

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -103,6 +103,7 @@ pub struct BaseBehaviour {
     outbound_conns: HashMap<PeerId, u32>,
     registered_workers: Arc<RwLock<HashSet<PeerId>>>,
     whitelist_initialized: bool,
+    first_identification_received: bool,
 }
 
 #[allow(dead_code)]
@@ -175,6 +176,7 @@ impl BaseBehaviour {
             outbound_conns: Default::default(),
             registered_workers: Arc::new(RwLock::new(Default::default())),
             whitelist_initialized: false,
+            first_identification_received: false,
         }
     }
 
@@ -237,6 +239,8 @@ pub enum BaseBehaviourEvent {
         stats: QueryStats,
         step: ProgressStep,
     },
+    NetworkConnected {
+    }
 }
 
 impl BehaviourWrapper for BaseBehaviour {
@@ -328,7 +332,13 @@ impl BaseBehaviour {
             self.inner.kademlia.add_address(&peer_id, addr);
         });
 
-        None
+        if self.first_identification_received {
+            None
+        } else {
+            Some(
+                ToSwarm::GenerateEvent(BaseBehaviourEvent::NetworkConnected {})
+            )
+        }
     }
 
     fn on_kademlia_event(&mut self, ev: kad::Event) -> Option<TToSwarm<Self>> {

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -103,7 +103,9 @@ pub struct BaseBehaviour {
     outbound_conns: HashMap<PeerId, u32>,
     registered_workers: Arc<RwLock<HashSet<PeerId>>>,
     whitelist_initialized: bool,
-    first_identification_received: bool,
+    identified_peers: HashSet<PeerId>,
+    /// Last confidence value sent, in tenths (0–10). None means nothing sent yet.
+    last_sent_confidence_step: Option<u8>,
 }
 
 #[allow(dead_code)]
@@ -176,7 +178,8 @@ impl BaseBehaviour {
             outbound_conns: Default::default(),
             registered_workers: Arc::new(RwLock::new(Default::default())),
             whitelist_initialized: false,
-            first_identification_received: false,
+            identified_peers: HashSet::new(),
+            last_sent_confidence_step: None,
         }
     }
 
@@ -240,7 +243,10 @@ pub enum BaseBehaviourEvent {
         step: ProgressStep,
     },
     NetworkConnected {
-    }
+        /// Connection confidence in range [0.1, 1.0], sent in steps of 0.1.
+        /// Reaches 1.0 when identified peers ≥ 75% of whitelist size.
+        confidence: f32,
+    },
 }
 
 impl BehaviourWrapper for BaseBehaviour {
@@ -332,14 +338,44 @@ impl BaseBehaviour {
             self.inner.kademlia.add_address(&peer_id, addr);
         });
 
-        if self.first_identification_received {
-            None
-        } else {
-            self.first_identification_received = true;
-            Some(
-                ToSwarm::GenerateEvent(BaseBehaviourEvent::NetworkConnected {})
-            )
+        self.identified_peers.insert(peer_id);
+        self.emit_confidence()
+    }
+
+    /// Compute current confidence and emit a `NetworkConnected` event if a new 0.1-step
+    /// threshold has been crossed for the first time. Returns `None` if the whitelist is
+    /// not yet initialised, if the computed step has already been sent, or if the step
+    /// would be 0 (first message must carry confidence ≥ 0.1).
+    fn emit_confidence(&mut self) -> Option<TToSwarm<Self>> {
+        if !self.whitelist_initialized {
+            return None;
         }
+        let whitelist_size = self.inner.whitelist.whitelist_size();
+        if whitelist_size == 0 {
+            return None;
+        }
+
+        // threshold = 75% of whitelist peers
+        let threshold = 0.75_f32 * whitelist_size as f32;
+        let raw = (self.identified_peers.len() as f32 / threshold).min(1.0_f32);
+
+        // Round down to the nearest 0.1 step (1–10 in tenths)
+        let step = (raw * 10.0_f32).floor() as u8;
+
+        // First message must have confidence >= 0.1 (step >= 1)
+        if step == 0 {
+            return None;
+        }
+
+        // Only emit when confidence increases; never send the same or lower value twice
+        if self.last_sent_confidence_step.is_some_and(|last| step <= last) {
+            return None;
+        }
+
+        self.last_sent_confidence_step = Some(step);
+        let confidence = step as f32 / 10.0_f32;
+        log::info!("Network confidence updated: {confidence:.1}");
+        Some(ToSwarm::GenerateEvent(BaseBehaviourEvent::NetworkConnected { confidence }))
     }
 
     fn on_kademlia_event(&mut self, ev: kad::Event) -> Option<TToSwarm<Self>> {

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -339,14 +339,14 @@ impl BaseBehaviour {
         });
 
         self.identified_peers.insert(peer_id);
-        self.emit_confidence()
+        self.try_emit_confidence()
     }
 
     /// Compute current confidence and emit a `NetworkConnected` event if a new 0.1-step
     /// threshold has been crossed for the first time. Returns `None` if the whitelist is
     /// not yet initialised, if the computed step has already been sent, or if the step
     /// would be 0 (first message must carry confidence ≥ 0.1).
-    fn emit_confidence(&mut self) -> Option<TToSwarm<Self>> {
+    fn try_emit_confidence(&mut self) -> Option<TToSwarm<Self>> {
         if !self.whitelist_initialized {
             return None;
         }
@@ -374,7 +374,7 @@ impl BaseBehaviour {
 
         self.last_sent_confidence_step = Some(step);
         let confidence = step as f32 / 10.0_f32;
-        log::info!("Network confidence updated: {confidence:.1}");
+        log::debug!("Network confidence updated: {confidence:.1}");
         Some(ToSwarm::GenerateEvent(BaseBehaviourEvent::NetworkConnected { confidence }))
     }
 

--- a/crates/transport/src/behaviour/node_whitelist.rs
+++ b/crates/transport/src/behaviour/node_whitelist.rs
@@ -50,6 +50,10 @@ impl WhitelistBehavior {
         }
     }
 
+    pub fn whitelist_size(&self) -> usize {
+        self.registered_nodes.len()
+    }
+
     pub fn allow_peer(&mut self, peer_id: PeerId) {
         log::debug!("Allowing peer {peer_id}");
         self.allow.allow_peer(peer_id);


### PR DESCRIPTION
Emit NetworkConnected with Confidence, derived from amount of unique Identify messages we got and total registered keys.
Use NetworkConnected message to advertise Portal Logs Collector service on time.