### PR TITLE
Support PortalRegistry with Fallback to GatewayRegistry NET-250

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-contract-client"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/contract-client/Cargo.toml
+++ b/crates/contract-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqd-contract-client"
 license = "AGPL-3.0-or-later"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/contract-client/abi/PortalRegistry.json
+++ b/crates/contract-client/abi/PortalRegistry.json
@@ -1,0 +1,1678 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "DEFAULT_ADMIN_ROLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_CLUSTERS_PER_OWNER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_PORTALS_PER_CLUSTER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PAUSER_ROLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "SQD",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IERC20"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "addPortal",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "peerId",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "metadata",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addressToClusterId",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allClusterIds",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "clusterCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "factory",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getActiveClusters",
+    "inputs": [
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clusterIds",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "clusters",
+        "type": "tuple[]",
+        "internalType": "struct IPortalRegistry.Cluster[]",
+        "components": [
+          {
+            "name": "clusterAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "totalStaked",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "registeredAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "metadata",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "portals",
+            "type": "tuple[]",
+            "internalType": "struct IPortalRegistry.Portal[]",
+            "components": [
+              {
+                "name": "peerId",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "metadata",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "addedAt",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "totalActive",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getCluster",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IPortalRegistry.Cluster",
+        "components": [
+          {
+            "name": "clusterAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "totalStaked",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "registeredAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "metadata",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "portals",
+            "type": "tuple[]",
+            "internalType": "struct IPortalRegistry.Portal[]",
+            "components": [
+              {
+                "name": "peerId",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "metadata",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "addedAt",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClusterByAddress",
+    "inputs": [
+      {
+        "name": "clusterAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IPortalRegistry.Cluster",
+        "components": [
+          {
+            "name": "clusterAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "totalStaked",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "registeredAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "metadata",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "portals",
+            "type": "tuple[]",
+            "internalType": "struct IPortalRegistry.Portal[]",
+            "components": [
+              {
+                "name": "peerId",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "metadata",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "addedAt",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClusterIdByAddress",
+    "inputs": [
+      {
+        "name": "clusterAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClusterIdByPeerId",
+    "inputs": [
+      {
+        "name": "peerId",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClusterPortals",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct IPortalRegistry.Portal[]",
+        "components": [
+          {
+            "name": "peerId",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "metadata",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "addedAt",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getClustersPaginated",
+    "inputs": [
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "limit",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clusterIds",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "clusters",
+        "type": "tuple[]",
+        "internalType": "struct IPortalRegistry.Cluster[]",
+        "components": [
+          {
+            "name": "clusterAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "operator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "totalStaked",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "registeredAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "active",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "metadata",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "portals",
+            "type": "tuple[]",
+            "internalType": "struct IPortalRegistry.Portal[]",
+            "components": [
+              {
+                "name": "peerId",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "metadata",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "addedAt",
+                "type": "uint64",
+                "internalType": "uint64"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getComputationUnits",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOperatorClusters",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPortalCount",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoleAdmin",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "grantRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "hasRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_sqd",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_minStake",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_mana",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isCluster",
+    "inputs": [
+      {
+        "name": "clusterAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mana",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minStake",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "multicall",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "results",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "ownerClusters",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "peerIdToCluster",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registerCluster",
+    "inputs": [
+      {
+        "name": "clusterAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "metadata",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removePortal",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "portalIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "callerConfirmation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "revokeRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setClusterMetadata",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "metadata",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setClusterMetadataByPool",
+    "inputs": [
+      {
+        "name": "metadata",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFactory",
+    "inputs": [
+      {
+        "name": "_factory",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMana",
+    "inputs": [
+      {
+        "name": "_mana",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMinStake",
+    "inputs": [
+      {
+        "name": "_minStake",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPortalMetadata",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "portalIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "metadata",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stake",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tryMulticall",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "successes",
+        "type": "bool[]",
+        "internalType": "bool[]"
+      },
+      {
+        "name": "results",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unstake",
+    "inputs": [
+      {
+        "name": "provider",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateClusterOperator",
+    "inputs": [
+      {
+        "name": "newOperator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "ClusterActivated",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClusterCreated",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "clusterAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClusterDeactivated",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClusterMetadataUpdated",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "metadata",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClusterOperatorUpdated",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "oldOperator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOperator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FactoryUpdated",
+    "inputs": [
+      {
+        "name": "oldFactory",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newFactory",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ManaUpdated",
+    "inputs": [
+      {
+        "name": "oldValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinStakeUpdated",
+    "inputs": [
+      {
+        "name": "oldValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PortalAdded",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "peerId",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "metadata",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PortalMetadataUpdated",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "portalIndex",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "metadata",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PortalRemoved",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "peerId",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleAdminChanged",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "previousAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleGranted",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleRevoked",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Staked",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unstaked",
+    "inputs": [
+      {
+        "name": "clusterId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccessControlBadConfirmation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AccessControlUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "neededRole",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ClusterAlreadyRegistered",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ClusterNotRegistered",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EnforcedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ExpectedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientAllocation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPeerId",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPortalIndex",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidStakeTransfer",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxClustersReached",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxPortalsReached",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotClusterOperator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OnlyFactory",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PeerIdInUse",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  }
+]

--- a/crates/contract-client/src/cli.rs
+++ b/crates/contract-client/src/cli.rs
@@ -28,6 +28,11 @@ pub struct RpcArgs {
     /// Path to dummy client data file (if set, use dummy client instead of EthersClient)
     #[arg(long, env)]
     pub dummy_client_file_path: Option<String>,
+
+    /// Disable the new PortalRegistry path entirely (fall back to legacy GatewayRegistry only).
+    /// Useful as a rollback switch during the PortalRegistry migration.
+    #[arg(long, env, default_value_t = false)]
+    pub disable_portal_registry: bool,
 }
 
 impl RpcArgs {
@@ -60,6 +65,15 @@ impl RpcArgs {
             .multicall_contract_addr
             .unwrap_or_else(|| self.network.multicall_default_addr())
     }
+
+    /// Returns the configured PortalRegistry address, falling back to the network default.
+    /// May be `None` (e.g. on Tethys, which is opt-in only) — callers must handle that case
+    /// to keep the legacy-only code path operational.
+    pub fn portal_registry_addr(&self) -> Option<Address> {
+        self.contract_addrs
+            .portal_registry_contract_addr
+            .or_else(|| self.network.portal_registry_default_addr())
+    }
 }
 
 #[derive(Args, Clone)]
@@ -74,6 +88,10 @@ pub struct ContractAddrs {
     pub allocations_viewer_contract_addr: Option<Address>,
     #[arg(long, env)]
     pub multicall_contract_addr: Option<Address>,
+    /// New PortalRegistry contract address. On mainnet this defaults to the deployed proxy;
+    /// on Tethys it defaults to `None` and operators must opt in via this env var.
+    #[arg(long, env)]
+    pub portal_registry_contract_addr: Option<Address>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -118,6 +136,15 @@ impl Network {
             Self::Tethys | Self::Mainnet => {
                 "0xcA11bde05977b3631167028862bE2a173976CA11".parse().unwrap()
             }
+        }
+    }
+
+    /// Default PortalRegistry proxy address per network. `None` on Tethys keeps the new code
+    /// path opt-in for staging until operators export `PORTAL_REGISTRY_CONTRACT_ADDR`.
+    pub fn portal_registry_default_addr(&self) -> Option<Address> {
+        match self {
+            Self::Tethys => None,
+            Self::Mainnet => Some("0x29edE9EB0ad3C02B6A98B0E41bF99Cd709812850".parse().unwrap()),
         }
     }
 }

--- a/crates/contract-client/src/client.rs
+++ b/crates/contract-client/src/client.rs
@@ -10,21 +10,30 @@ use std::{
 use async_trait::async_trait;
 use ethers::{
     prelude::{BlockId, Bytes, Middleware, Multicall, Provider},
-    types::{BlockNumber, H160},
+    types::{BlockNumber, H160, U64},
 };
 use libp2p::futures::Stream;
 use num_rational::Ratio;
-use tokio_stream::{wrappers::IntervalStream, StreamExt};
 use serde::Deserialize;
+use tokio_stream::{wrappers::IntervalStream, StreamExt};
 
 use crate::{
     contracts,
     contracts::{
-        AllocationsViewer, GatewayRegistry, NetworkController, Strategy, WorkerRegistration,
+        AllocationsViewer, GatewayRegistry, NetworkController, PortalRegistry, Strategy,
+        WorkerRegistration,
     },
     transport::Transport,
     Address, ClientError, PeerId, RpcArgs, U256,
 };
+
+/// Zero value for `bytes32`. `abigen!` emits Solidity `bytes32` as `[u8; 32]`, which has no
+/// `is_zero()` helper, so we compare against this constant for the "not registered" branch.
+const ZERO_CLUSTER_ID: [u8; 32] = [0u8; 32];
+
+/// SQD token decimals (1e18). Used to scale `Stake.amount` / `Cluster.totalStaked` (in wei) to a
+/// human-readable `Ratio<u128>`.
+const SQD_DECIMALS_DENOM: u128 = 1_000_000_000_000_000_000;
 
 #[derive(Debug, Clone)]
 pub struct Allocation {
@@ -242,11 +251,15 @@ impl DummyClient {
     }
 
     fn parse_u256(u256_str: &str) -> Result<U256, ClientError> {
-        Ok(u256_str.parse().map_err(|_| ClientError::Contract(format!("Invalid U256: {}", u256_str)))?)
+        u256_str
+            .parse()
+            .map_err(|_| ClientError::Contract(format!("Invalid U256: {}", u256_str)))
     }
 
     fn parse_address(addr_str: &str) -> Result<Address, ClientError> {
-        Ok(addr_str.parse().map_err(|_| ClientError::Contract(format!("Invalid Address: {}", addr_str)))?)
+        addr_str
+            .parse()
+            .map_err(|_| ClientError::Contract(format!("Invalid Address: {}", addr_str)))
     }
 }
 
@@ -278,16 +291,20 @@ impl Client for DummyClient {
     }
 
     async fn active_workers(&self) -> Result<Vec<Worker>, ClientError> {
-        self.data.workers.iter().map(|w| {
-            Ok(Worker {
-                peer_id: Self::parse_peer_id(&w.peer_id)?,
-                onchain_id: Self::parse_u256(&w.onchain_id)?,
-                address: Self::parse_address(&w.address)?,
-                bond: Self::parse_u256(&w.bond)?,
-                registered_at: w.registered_at,
-                deregistered_at: w.deregistered_at,
+        self.data
+            .workers
+            .iter()
+            .map(|w| {
+                Ok(Worker {
+                    peer_id: Self::parse_peer_id(&w.peer_id)?,
+                    onchain_id: Self::parse_u256(&w.onchain_id)?,
+                    address: Self::parse_address(&w.address)?,
+                    bond: Self::parse_u256(&w.bond)?,
+                    registered_at: w.registered_at,
+                    deregistered_at: w.deregistered_at,
+                })
             })
-        }).collect()
+            .collect()
     }
 
     async fn is_portal_registered(&self, portal_id: PeerId) -> Result<bool, ClientError> {
@@ -308,9 +325,7 @@ impl Client for DummyClient {
     }
 
     async fn active_portals(&self) -> Result<Vec<PeerId>, ClientError> {
-        self.data.portals.iter()
-            .map(|s| Self::parse_peer_id(s))
-            .collect()
+        self.data.portals.iter().map(|s| Self::parse_peer_id(s)).collect()
     }
 
     async fn current_allocations(
@@ -326,43 +341,49 @@ impl Client for DummyClient {
             return Ok(vec![]);
         }
         let portal_id_str = portal_id.to_string();
-        let cus_per_epoch = self.data.portal_compute_units
-            .get(&portal_id_str)
-            .copied()
-            .unwrap_or(0);
-        Ok(workers.into_iter().map(|w| Allocation {
-            worker_peer_id: w.peer_id,
-            worker_onchain_id: w.onchain_id,
-            computation_units: U256::from(cus_per_epoch),
-        }).collect())
+        let cus_per_epoch =
+            self.data.portal_compute_units.get(&portal_id_str).copied().unwrap_or(0);
+        Ok(workers
+            .into_iter()
+            .map(|w| Allocation {
+                worker_peer_id: w.peer_id,
+                worker_onchain_id: w.onchain_id,
+                computation_units: U256::from(cus_per_epoch),
+            })
+            .collect())
     }
 
     async fn portal_compute_units_per_epoch(&self, portal_id: PeerId) -> Result<u64, ClientError> {
         let portal_id_str = portal_id.to_string();
-        Ok(self.data.portal_compute_units
-            .get(&portal_id_str)
-            .copied()
-            .unwrap_or(0))
+        Ok(self.data.portal_compute_units.get(&portal_id_str).copied().unwrap_or(0))
     }
 
     async fn portal_uses_default_strategy(&self, portal_id: PeerId) -> Result<bool, ClientError> {
         let portal_id_str = portal_id.to_string();
-        Ok(self.data.portal_uses_default_strategy
+        Ok(self
+            .data
+            .portal_uses_default_strategy
             .get(&portal_id_str)
             .copied()
             .unwrap_or(true))
     }
 
     async fn portal_clusters(&self, _worker_id: U256) -> Result<Vec<PortalCluster>, ClientError> {
-        self.data.portal_clusters.iter().map(|c| {
-            Ok(PortalCluster {
-                operator_addr: Self::parse_address(&c.operator_addr)?,
-                portal_ids: c.portal_ids.iter()
-                    .map(|s| Self::parse_peer_id(s))
-                    .collect::<Result<Vec<_>, _>>()?,
-                allocated_computation_units: Self::parse_u256(&c.allocated_computation_units)?,
+        self.data
+            .portal_clusters
+            .iter()
+            .map(|c| {
+                Ok(PortalCluster {
+                    operator_addr: Self::parse_address(&c.operator_addr)?,
+                    portal_ids: c
+                        .portal_ids
+                        .iter()
+                        .map(|s| Self::parse_peer_id(s))
+                        .collect::<Result<Vec<_>, _>>()?,
+                    allocated_computation_units: Self::parse_u256(&c.allocated_computation_units)?,
+                })
             })
-        }).collect()
+            .collect()
     }
 
     async fn portal_sqd_locked(
@@ -389,6 +410,10 @@ struct EthersClient {
     network_controller: NetworkController<Provider<Transport>>,
     worker_registration: WorkerRegistration<Provider<Transport>>,
     allocations_viewer: AllocationsViewer<Provider<Transport>>,
+    /// New PortalRegistry handle. `None` when the registry is disabled via the rollback flag
+    /// or when no address is configured for the active network (e.g. Tethys without an env
+    /// override). Every method that consults the new registry must guard on this `Option`.
+    portal_registry: Option<PortalRegistry<Provider<Transport>>>,
     default_strategy_addr: Address,
     multicall_contract_addr: Option<Address>,
     active_workers_per_page: usize,
@@ -416,6 +441,31 @@ impl EthersClient {
         let allocations_viewer =
             AllocationsViewer::get(l2_client.clone(), rpc_args.allocations_viewer_addr());
         log::info!("Multicall: {}", rpc_args.multicall_addr());
+
+        // Portal Pools migration: try the new PortalRegistry first, fall back to the legacy
+        // GatewayRegistry/AllocationsViewer when the peer ID isn't migrated yet. The registry
+        // is opt-out (via --disable-portal-registry) on Mainnet and opt-in (no default address)
+        // on Tethys, so a missing address simply degrades to legacy-only behavior.
+        let portal_registry =
+            match (rpc_args.disable_portal_registry, rpc_args.portal_registry_addr()) {
+                (true, _) => {
+                    log::info!("PortalRegistry: disabled by --disable-portal-registry");
+                    None
+                }
+                (false, Some(addr)) => {
+                    log::info!("PortalRegistry: {addr}");
+                    Some(PortalRegistry::get(l2_client.clone(), addr))
+                }
+                (false, None) => {
+                    log::info!(
+                        "PortalRegistry: no address configured for {} — set \
+                         PORTAL_REGISTRY_CONTRACT_ADDR to enable",
+                        rpc_args.network
+                    );
+                    None
+                }
+            };
+
         Ok(Box::new(Self {
             l1_client,
             l2_client,
@@ -423,6 +473,7 @@ impl EthersClient {
             worker_registration,
             network_controller,
             allocations_viewer,
+            portal_registry,
             default_strategy_addr,
             multicall_contract_addr: Some(rpc_args.multicall_addr()),
             active_workers_per_page: rpc_args.contract_workers_per_page,
@@ -432,6 +483,42 @@ impl EthersClient {
 
     async fn multicall(&self) -> Result<Multicall<Provider<Transport>>, ClientError> {
         Ok(contracts::multicall(self.l2_client.clone(), self.multicall_contract_addr).await?)
+    }
+
+    async fn active_workers_at(&self, latest_block: U64) -> Result<Vec<Worker>, ClientError> {
+        // A single getActiveWorkers call should be used instead but it lacks pagination and runs out of gas
+
+        let onchain_ids: Vec<U256> = self
+            .worker_registration
+            .get_active_worker_ids()
+            .block(latest_block)
+            .call()
+            .await?;
+        let calls = onchain_ids.chunks(self.active_workers_per_page).map(|ids| async move {
+            let mut multicall = self.multicall().await?.block(latest_block);
+            for id in ids {
+                multicall.add_call::<contracts::Worker>(
+                    self.worker_registration.method("getWorker", *id)?,
+                    false,
+                );
+            }
+            let workers: Vec<contracts::Worker> = multicall.call_array().await?;
+            Result::<_, ClientError>::Ok(workers)
+        });
+
+        let workers = futures::future::try_join_all(calls).await?.into_iter().flatten();
+
+        let workers = workers
+            .zip(onchain_ids)
+            .filter_map(|(worker, onchain_id)| match Worker::new(&worker, onchain_id) {
+                Ok(worker) => Some(worker),
+                Err(e) => {
+                    log::debug!("Error reading worker from chain: {e:?}");
+                    None
+                }
+            })
+            .collect();
+        Ok(workers)
     }
 }
 
@@ -499,42 +586,31 @@ impl Client for EthersClient {
     }
 
     async fn active_workers(&self) -> Result<Vec<Worker>, ClientError> {
-        // A single getActiveWorkers call should be used instead but it lacks pagination and runs out of gas
-
-        let onchain_ids: Vec<U256> =
-            self.worker_registration.get_active_worker_ids().call().await?;
-        let calls = onchain_ids.chunks(self.active_workers_per_page).map(|ids| async move {
-            let mut multicall = self.multicall().await?;
-            for id in ids {
-                multicall.add_call::<contracts::Worker>(
-                    self.worker_registration.method("getWorker", *id)?,
-                    false,
-                );
-            }
-            let workers: Vec<contracts::Worker> = multicall.call_array().await?;
-            Result::<_, ClientError>::Ok(workers)
-        });
-
-        let workers = futures::future::try_join_all(calls).await?.into_iter().flatten();
-
-        let workers = workers
-            .zip(onchain_ids)
-            .filter_map(|(worker, onchain_id)| match Worker::new(&worker, onchain_id) {
-                Ok(worker) => Some(worker),
-                Err(e) => {
-                    log::debug!("Error reading worker from chain: {e:?}");
-                    None
-                }
-            })
-            .collect();
-        Ok(workers)
+        let latest_block = self.l2_client.get_block_number().await?;
+        self.active_workers_at(latest_block).await
     }
 
     async fn is_portal_registered(&self, portal_id: PeerId) -> Result<bool, ClientError> {
-        let portal_id = portal_id.to_bytes().into();
+        let id_bytes: Bytes = portal_id.to_bytes().into();
+        let latest_block = self.l2_client.get_block_number().await?;
+        if let Some(pr) = &self.portal_registry {
+            let cluster_id = pr
+                .get_cluster_id_by_peer_id(id_bytes.clone())
+                .block(latest_block)
+                .call()
+                .await?;
+            if cluster_id != ZERO_CLUSTER_ID {
+                log::debug!("portal {portal_id} resolved via PortalRegistry");
+                return Ok(true);
+            }
+        }
         let portal_info: contracts::Gateway =
-            self.gateway_registry.get_gateway(portal_id).call().await?;
-        Ok(portal_info.operator != Address::zero())
+            self.gateway_registry.get_gateway(id_bytes).block(latest_block).call().await?;
+        let registered = portal_info.operator != Address::zero();
+        if registered {
+            log::debug!("portal {portal_id} resolved via GatewayRegistry");
+        }
+        Ok(registered)
     }
 
     async fn worker_registration_time(
@@ -561,7 +637,32 @@ impl Client for EthersClient {
 
     async fn active_portals(&self) -> Result<Vec<PeerId>, ClientError> {
         let latest_block = self.l2_client.get_block_number().await?;
-        let mut active_portals = Vec::new();
+
+        // PortalRegistry: enumerate active clusters and flatten their portal lists.
+        let mut new_portals: Vec<PeerId> = Vec::new();
+        if let Some(pr) = &self.portal_registry {
+            let mut offset = U256::zero();
+            let limit = self.portals_per_page;
+            loop {
+                let (_cluster_ids, clusters, total_active) =
+                    pr.get_active_clusters(offset, limit).block(latest_block).call().await?;
+                let page_len = clusters.len();
+                for c in &clusters {
+                    for p in &c.portals {
+                        if let Ok(peer_id) = PeerId::from_bytes(&p.peer_id) {
+                            new_portals.push(peer_id);
+                        }
+                    }
+                }
+                offset += U256::from(page_len);
+                if page_len == 0 || offset >= total_active {
+                    break;
+                }
+            }
+        }
+
+        // Legacy GatewayRegistry: keep the old enumeration so un-migrated gateways stay served.
+        let mut legacy_portals: Vec<PeerId> = Vec::new();
         for page in 0.. {
             let portal_ids = self
                 .gateway_registry
@@ -570,13 +671,13 @@ impl Client for EthersClient {
                 .call()
                 .await?;
             let page_size = U256::from(portal_ids.len());
-
-            active_portals.extend(portal_ids.iter().filter_map(|id| PeerId::from_bytes(id).ok()));
+            legacy_portals.extend(portal_ids.iter().filter_map(|id| PeerId::from_bytes(id).ok()));
             if page_size < self.portals_per_page {
                 break;
             }
         }
-        Ok(active_portals)
+
+        Ok(crate::merge::merge_active_portals(new_portals, legacy_portals))
     }
 
     async fn current_allocations(
@@ -584,25 +685,69 @@ impl Client for EthersClient {
         portal_id: PeerId,
         workers: Option<Vec<Worker>>,
     ) -> Result<Vec<Allocation>, ClientError> {
+        let latest_block = self.l2_client.get_block_number().await?;
         let workers = match workers {
             Some(workers) => workers,
-            None => self.active_workers().await?,
+            None => self.active_workers_at(latest_block).await?,
         };
         if workers.is_empty() {
             return Ok(vec![]);
         }
 
-        let portal_id: Bytes = portal_id.to_bytes().into();
-        let strategy_addr =
-            self.gateway_registry.get_used_strategy(portal_id.clone()).call().await?;
+        let id_bytes: Bytes = portal_id.to_bytes().into();
+
+        // PortalRegistry path: equal-split the cluster's CUs across all active workers, then
+        // project that per-worker value onto the caller's requested worker set.
+        if let Some(pr) = &self.portal_registry {
+            let cluster_id = pr
+                .get_cluster_id_by_peer_id(id_bytes.clone())
+                .block(latest_block)
+                .call()
+                .await?;
+            if cluster_id != ZERO_CLUSTER_ID {
+                log::debug!("portal {portal_id} resolved via PortalRegistry");
+                let cus_total =
+                    pr.get_computation_units(cluster_id).block(latest_block).call().await?;
+                let active_worker_count: U256 = self
+                    .worker_registration
+                    .get_active_worker_count()
+                    .block(latest_block)
+                    .call()
+                    .await?;
+                if active_worker_count.is_zero() {
+                    return Ok(vec![]);
+                }
+                let per_worker = cus_total / active_worker_count;
+                return Ok(workers
+                    .into_iter()
+                    .map(|w| Allocation {
+                        worker_peer_id: w.peer_id,
+                        worker_onchain_id: w.onchain_id,
+                        computation_units: per_worker,
+                    })
+                    .collect());
+            }
+        }
+
+        // Legacy GatewayRegistry strategy path.
+        log::debug!("portal {portal_id} resolved via GatewayRegistry");
+        let strategy_addr = self
+            .gateway_registry
+            .get_used_strategy(id_bytes.clone())
+            .block(latest_block)
+            .call()
+            .await?;
         let strategy = Strategy::get(strategy_addr, self.l2_client.clone());
 
         // A little hack to make less requests: default strategy distributes CUs evenly,
         // so we can just query for one worker and return the same number for all.
         if strategy_addr == self.default_strategy_addr {
             let first_worker_id = workers.first().expect("non empty").onchain_id;
-            let cus_per_epoch =
-                strategy.computation_units_per_epoch(portal_id, first_worker_id).call().await?;
+            let cus_per_epoch = strategy
+                .computation_units_per_epoch(id_bytes, first_worker_id)
+                .block(latest_block)
+                .call()
+                .await?;
             return Ok(workers
                 .into_iter()
                 .map(|w| Allocation {
@@ -613,11 +758,11 @@ impl Client for EthersClient {
                 .collect());
         }
 
-        let mut multicall = self.multicall().await?;
+        let mut multicall = self.multicall().await?.block(latest_block);
         for worker in &workers {
             multicall.add_call::<U256>(
                 strategy
-                    .method("computationUnitsPerEpoch", (portal_id.clone(), worker.onchain_id))?,
+                    .method("computationUnitsPerEpoch", (id_bytes.clone(), worker.onchain_id))?,
                 false,
             );
         }
@@ -632,21 +777,117 @@ impl Client for EthersClient {
     }
 
     async fn portal_compute_units_per_epoch(&self, portal_id: PeerId) -> Result<u64, ClientError> {
-        let id: Bytes = portal_id.to_bytes().into();
-        let cus = self.gateway_registry.computation_units_available(id).call().await?;
+        let id_bytes: Bytes = portal_id.to_bytes().into();
+        let latest_block = self.l2_client.get_block_number().await?;
+        if let Some(pr) = &self.portal_registry {
+            let cluster_id = pr
+                .get_cluster_id_by_peer_id(id_bytes.clone())
+                .block(latest_block)
+                .call()
+                .await?;
+            if cluster_id != ZERO_CLUSTER_ID {
+                log::debug!("portal {portal_id} resolved via PortalRegistry");
+                let cus = pr.get_computation_units(cluster_id).block(latest_block).call().await?;
+                return Ok(cus.try_into().expect("Computation units should not exceed u64 range"));
+            }
+        }
+        log::debug!("portal {portal_id} resolved via GatewayRegistry");
+        let cus = self
+            .gateway_registry
+            .computation_units_available(id_bytes)
+            .block(latest_block)
+            .call()
+            .await?;
         Ok(cus.try_into().expect("Computation units should not exceed u64 range"))
     }
 
     async fn portal_uses_default_strategy(&self, portal_id: PeerId) -> Result<bool, ClientError> {
-        let id: Bytes = portal_id.to_bytes().into();
-        let strategy_addr = self.gateway_registry.get_used_strategy(id).call().await?;
+        let id_bytes: Bytes = portal_id.to_bytes().into();
+        let latest_block = self.l2_client.get_block_number().await?;
+        // PortalRegistry has no strategy concept — every cluster behaves like an equal-split
+        // default strategy. If the peer is registered there, return true unconditionally.
+        if let Some(pr) = &self.portal_registry {
+            let cluster_id = pr
+                .get_cluster_id_by_peer_id(id_bytes.clone())
+                .block(latest_block)
+                .call()
+                .await?;
+            if cluster_id != ZERO_CLUSTER_ID {
+                log::debug!("portal {portal_id} resolved via PortalRegistry");
+                return Ok(true);
+            }
+        }
+        log::debug!("portal {portal_id} resolved via GatewayRegistry");
+        let strategy_addr = self
+            .gateway_registry
+            .get_used_strategy(id_bytes)
+            .block(latest_block)
+            .call()
+            .await?;
         Ok(strategy_addr == self.default_strategy_addr)
     }
 
     async fn portal_clusters(&self, worker_id: U256) -> Result<Vec<PortalCluster>, ClientError> {
         let latest_block = self.l2_client.get_block_number().await?;
 
-        let mut clusters = HashMap::new();
+        // PortalRegistry: equal-split each active cluster's CUs across the active worker set.
+        let mut new_clusters: Vec<PortalCluster> = Vec::new();
+        if let Some(pr) = &self.portal_registry {
+            let active_worker_count: U256 = self
+                .worker_registration
+                .get_active_worker_count()
+                .block(latest_block)
+                .call()
+                .await?;
+            if !active_worker_count.is_zero() {
+                let mut offset = U256::zero();
+                let limit = self.portals_per_page;
+                loop {
+                    let (cluster_ids, clusters, total_active) =
+                        pr.get_active_clusters(offset, limit).block(latest_block).call().await?;
+                    let page_len = clusters.len();
+
+                    let cluster_cus: Vec<U256> = if cluster_ids.is_empty() {
+                        Vec::new()
+                    } else {
+                        let mut mc = self.multicall().await?.block(latest_block);
+                        for cid in &cluster_ids {
+                            mc.add_call::<U256>(pr.method("getComputationUnits", *cid)?, false);
+                        }
+                        mc.call_array().await?
+                    };
+
+                    for (cluster, cus_total) in clusters.iter().zip(cluster_cus) {
+                        let per_worker = cus_total / active_worker_count;
+                        if per_worker.is_zero() {
+                            continue;
+                        }
+                        let portal_ids: Vec<PeerId> = cluster
+                            .portals
+                            .iter()
+                            .filter_map(|p| PeerId::from_bytes(&p.peer_id).ok())
+                            .collect();
+                        if portal_ids.is_empty() {
+                            continue;
+                        }
+                        new_clusters.push(PortalCluster {
+                            operator_addr: cluster.operator,
+                            portal_ids,
+                            allocated_computation_units: per_worker,
+                        });
+                    }
+
+                    offset += U256::from(page_len);
+                    if page_len == 0 || offset >= total_active {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Legacy AllocationsViewer rows; the merge layer dedupes migrated peer IDs and groups
+        // surviving entries by operator.
+        let mut legacy_allocations: Vec<contracts::Allocation> = Vec::new();
         for page in 0.. {
             let allocations = self
                 .allocations_viewer
@@ -655,46 +896,50 @@ impl Client for EthersClient {
                 .call()
                 .await?;
             let page_size = U256::from(allocations.len());
-
-            for allocation in allocations {
-                let Ok(portal_peer_id) = PeerId::from_bytes(&allocation.gateway_id) else {
-                    continue;
-                };
-                clusters
-                    .entry(allocation.operator)
-                    .or_insert_with(|| PortalCluster {
-                        operator_addr: allocation.operator,
-                        portal_ids: Vec::new(),
-                        allocated_computation_units: allocation.allocated,
-                    })
-                    .portal_ids
-                    .push(portal_peer_id);
-            }
-
+            legacy_allocations.extend(allocations);
             if page_size < self.portals_per_page {
                 break;
             }
         }
-        Ok(clusters.into_values().collect())
+
+        Ok(crate::merge::merge_portal_clusters(new_clusters, legacy_allocations))
     }
 
     async fn portal_sqd_locked(
         &self,
         portal_id: PeerId,
     ) -> Result<Option<(String, Ratio<u128>)>, ClientError> {
-        let id: Bytes = portal_id.to_bytes().into();
-        let portal = self.gateway_registry.get_gateway(id).call().await?;
+        let id_bytes: Bytes = portal_id.to_bytes().into();
+        let latest_block = self.l2_client.get_block_number().await?;
 
+        if let Some(pr) = &self.portal_registry {
+            let cluster_id = pr
+                .get_cluster_id_by_peer_id(id_bytes.clone())
+                .block(latest_block)
+                .call()
+                .await?;
+            if cluster_id != ZERO_CLUSTER_ID {
+                log::debug!("portal {portal_id} resolved via PortalRegistry");
+                let cluster = pr.get_cluster(cluster_id).block(latest_block).call().await?;
+                if !cluster.operator.is_zero() {
+                    return Ok(Some((
+                        cluster.operator.to_string(),
+                        Ratio::new(cluster.total_staked.as_u128(), SQD_DECIMALS_DENOM),
+                    )));
+                }
+            }
+        }
+
+        log::debug!("portal {portal_id} resolved via GatewayRegistry");
+        let portal = self.gateway_registry.get_gateway(id_bytes).block(latest_block).call().await?;
         let operator: H160 = portal.operator;
         if operator.is_zero() {
             return Ok(None);
         }
-
-        let stake = self.gateway_registry.get_stake(operator).call().await?;
-
+        let stake = self.gateway_registry.get_stake(operator).block(latest_block).call().await?;
         Ok(Some((
             operator.to_string(),
-            Ratio::new(stake.amount.as_u128(), 1_000_000_000_000_000_000),
+            Ratio::new(stake.amount.as_u128(), SQD_DECIMALS_DENOM),
         )))
     }
 }

--- a/crates/contract-client/src/client.rs
+++ b/crates/contract-client/src/client.rs
@@ -10,7 +10,7 @@ use std::{
 use async_trait::async_trait;
 use ethers::{
     prelude::{BlockId, Bytes, Middleware, Multicall, Provider},
-    types::{BlockNumber, H160, U64},
+    types::{BlockNumber, H160},
 };
 use libp2p::futures::Stream;
 use num_rational::Ratio;
@@ -484,42 +484,6 @@ impl EthersClient {
     async fn multicall(&self) -> Result<Multicall<Provider<Transport>>, ClientError> {
         Ok(contracts::multicall(self.l2_client.clone(), self.multicall_contract_addr).await?)
     }
-
-    async fn active_workers_at(&self, latest_block: U64) -> Result<Vec<Worker>, ClientError> {
-        // A single getActiveWorkers call should be used instead but it lacks pagination and runs out of gas
-
-        let onchain_ids: Vec<U256> = self
-            .worker_registration
-            .get_active_worker_ids()
-            .block(latest_block)
-            .call()
-            .await?;
-        let calls = onchain_ids.chunks(self.active_workers_per_page).map(|ids| async move {
-            let mut multicall = self.multicall().await?.block(latest_block);
-            for id in ids {
-                multicall.add_call::<contracts::Worker>(
-                    self.worker_registration.method("getWorker", *id)?,
-                    false,
-                );
-            }
-            let workers: Vec<contracts::Worker> = multicall.call_array().await?;
-            Result::<_, ClientError>::Ok(workers)
-        });
-
-        let workers = futures::future::try_join_all(calls).await?.into_iter().flatten();
-
-        let workers = workers
-            .zip(onchain_ids)
-            .filter_map(|(worker, onchain_id)| match Worker::new(&worker, onchain_id) {
-                Ok(worker) => Some(worker),
-                Err(e) => {
-                    log::debug!("Error reading worker from chain: {e:?}");
-                    None
-                }
-            })
-            .collect();
-        Ok(workers)
-    }
 }
 
 #[async_trait]
@@ -586,26 +550,48 @@ impl Client for EthersClient {
     }
 
     async fn active_workers(&self) -> Result<Vec<Worker>, ClientError> {
-        let latest_block = self.l2_client.get_block_number().await?;
-        self.active_workers_at(latest_block).await
+        // A single getActiveWorkers call should be used instead but it lacks pagination and runs out of gas
+
+        let onchain_ids: Vec<U256> =
+            self.worker_registration.get_active_worker_ids().call().await?;
+        let calls = onchain_ids.chunks(self.active_workers_per_page).map(|ids| async move {
+            let mut multicall = self.multicall().await?;
+            for id in ids {
+                multicall.add_call::<contracts::Worker>(
+                    self.worker_registration.method("getWorker", *id)?,
+                    false,
+                );
+            }
+            let workers: Vec<contracts::Worker> = multicall.call_array().await?;
+            Result::<_, ClientError>::Ok(workers)
+        });
+
+        let workers = futures::future::try_join_all(calls).await?.into_iter().flatten();
+
+        let workers = workers
+            .zip(onchain_ids)
+            .filter_map(|(worker, onchain_id)| match Worker::new(&worker, onchain_id) {
+                Ok(worker) => Some(worker),
+                Err(e) => {
+                    log::debug!("Error reading worker from chain: {e:?}");
+                    None
+                }
+            })
+            .collect();
+        Ok(workers)
     }
 
     async fn is_portal_registered(&self, portal_id: PeerId) -> Result<bool, ClientError> {
         let id_bytes: Bytes = portal_id.to_bytes().into();
-        let latest_block = self.l2_client.get_block_number().await?;
         if let Some(pr) = &self.portal_registry {
-            let cluster_id = pr
-                .get_cluster_id_by_peer_id(id_bytes.clone())
-                .block(latest_block)
-                .call()
-                .await?;
+            let cluster_id = pr.get_cluster_id_by_peer_id(id_bytes.clone()).call().await?;
             if cluster_id != ZERO_CLUSTER_ID {
                 log::debug!("portal {portal_id} resolved via PortalRegistry");
                 return Ok(true);
             }
         }
         let portal_info: contracts::Gateway =
-            self.gateway_registry.get_gateway(id_bytes).block(latest_block).call().await?;
+            self.gateway_registry.get_gateway(id_bytes).call().await?;
         let registered = portal_info.operator != Address::zero();
         if registered {
             log::debug!("portal {portal_id} resolved via GatewayRegistry");
@@ -636,8 +622,6 @@ impl Client for EthersClient {
     }
 
     async fn active_portals(&self) -> Result<Vec<PeerId>, ClientError> {
-        let latest_block = self.l2_client.get_block_number().await?;
-
         // PortalRegistry: enumerate active clusters and flatten their portal lists.
         let mut new_portals: Vec<PeerId> = Vec::new();
         if let Some(pr) = &self.portal_registry {
@@ -645,7 +629,7 @@ impl Client for EthersClient {
             let limit = self.portals_per_page;
             loop {
                 let (_cluster_ids, clusters, total_active) =
-                    pr.get_active_clusters(offset, limit).block(latest_block).call().await?;
+                    pr.get_active_clusters(offset, limit).call().await?;
                 let page_len = clusters.len();
                 for c in &clusters {
                     for p in &c.portals {
@@ -667,7 +651,6 @@ impl Client for EthersClient {
             let portal_ids = self
                 .gateway_registry
                 .get_active_gateways(page.into(), self.portals_per_page)
-                .block(latest_block)
                 .call()
                 .await?;
             let page_size = U256::from(portal_ids.len());
@@ -685,10 +668,9 @@ impl Client for EthersClient {
         portal_id: PeerId,
         workers: Option<Vec<Worker>>,
     ) -> Result<Vec<Allocation>, ClientError> {
-        let latest_block = self.l2_client.get_block_number().await?;
         let workers = match workers {
             Some(workers) => workers,
-            None => self.active_workers_at(latest_block).await?,
+            None => self.active_workers().await?,
         };
         if workers.is_empty() {
             return Ok(vec![]);
@@ -696,34 +678,18 @@ impl Client for EthersClient {
 
         let id_bytes: Bytes = portal_id.to_bytes().into();
 
-        // PortalRegistry path: equal-split the cluster's CUs across all active workers, then
-        // project that per-worker value onto the caller's requested worker set.
+        // PortalRegistry path: the contract returns the final CU value for each worker.
         if let Some(pr) = &self.portal_registry {
-            let cluster_id = pr
-                .get_cluster_id_by_peer_id(id_bytes.clone())
-                .block(latest_block)
-                .call()
-                .await?;
+            let cluster_id = pr.get_cluster_id_by_peer_id(id_bytes.clone()).call().await?;
             if cluster_id != ZERO_CLUSTER_ID {
                 log::debug!("portal {portal_id} resolved via PortalRegistry");
-                let cus_total =
-                    pr.get_computation_units(cluster_id).block(latest_block).call().await?;
-                let active_worker_count: U256 = self
-                    .worker_registration
-                    .get_active_worker_count()
-                    .block(latest_block)
-                    .call()
-                    .await?;
-                if active_worker_count.is_zero() {
-                    return Ok(vec![]);
-                }
-                let per_worker = cus_total / active_worker_count;
+                let computation_units = pr.get_computation_units(cluster_id).call().await?;
                 return Ok(workers
                     .into_iter()
                     .map(|w| Allocation {
                         worker_peer_id: w.peer_id,
                         worker_onchain_id: w.onchain_id,
-                        computation_units: per_worker,
+                        computation_units,
                     })
                     .collect());
             }
@@ -731,23 +697,16 @@ impl Client for EthersClient {
 
         // Legacy GatewayRegistry strategy path.
         log::debug!("portal {portal_id} resolved via GatewayRegistry");
-        let strategy_addr = self
-            .gateway_registry
-            .get_used_strategy(id_bytes.clone())
-            .block(latest_block)
-            .call()
-            .await?;
+        let strategy_addr =
+            self.gateway_registry.get_used_strategy(id_bytes.clone()).call().await?;
         let strategy = Strategy::get(strategy_addr, self.l2_client.clone());
 
         // A little hack to make less requests: default strategy distributes CUs evenly,
         // so we can just query for one worker and return the same number for all.
         if strategy_addr == self.default_strategy_addr {
             let first_worker_id = workers.first().expect("non empty").onchain_id;
-            let cus_per_epoch = strategy
-                .computation_units_per_epoch(id_bytes, first_worker_id)
-                .block(latest_block)
-                .call()
-                .await?;
+            let cus_per_epoch =
+                strategy.computation_units_per_epoch(id_bytes, first_worker_id).call().await?;
             return Ok(workers
                 .into_iter()
                 .map(|w| Allocation {
@@ -758,7 +717,7 @@ impl Client for EthersClient {
                 .collect());
         }
 
-        let mut multicall = self.multicall().await?.block(latest_block);
+        let mut multicall = self.multicall().await?;
         for worker in &workers {
             multicall.add_call::<U256>(
                 strategy
@@ -778,109 +737,78 @@ impl Client for EthersClient {
 
     async fn portal_compute_units_per_epoch(&self, portal_id: PeerId) -> Result<u64, ClientError> {
         let id_bytes: Bytes = portal_id.to_bytes().into();
-        let latest_block = self.l2_client.get_block_number().await?;
         if let Some(pr) = &self.portal_registry {
-            let cluster_id = pr
-                .get_cluster_id_by_peer_id(id_bytes.clone())
-                .block(latest_block)
-                .call()
-                .await?;
+            let cluster_id = pr.get_cluster_id_by_peer_id(id_bytes.clone()).call().await?;
             if cluster_id != ZERO_CLUSTER_ID {
                 log::debug!("portal {portal_id} resolved via PortalRegistry");
-                let cus = pr.get_computation_units(cluster_id).block(latest_block).call().await?;
+                let cus = pr.get_computation_units(cluster_id).call().await?;
                 return Ok(cus.try_into().expect("Computation units should not exceed u64 range"));
             }
         }
         log::debug!("portal {portal_id} resolved via GatewayRegistry");
-        let cus = self
-            .gateway_registry
-            .computation_units_available(id_bytes)
-            .block(latest_block)
-            .call()
-            .await?;
+        let cus = self.gateway_registry.computation_units_available(id_bytes).call().await?;
         Ok(cus.try_into().expect("Computation units should not exceed u64 range"))
     }
 
     async fn portal_uses_default_strategy(&self, portal_id: PeerId) -> Result<bool, ClientError> {
         let id_bytes: Bytes = portal_id.to_bytes().into();
-        let latest_block = self.l2_client.get_block_number().await?;
         // PortalRegistry has no strategy concept — every cluster behaves like an equal-split
         // default strategy. If the peer is registered there, return true unconditionally.
         if let Some(pr) = &self.portal_registry {
-            let cluster_id = pr
-                .get_cluster_id_by_peer_id(id_bytes.clone())
-                .block(latest_block)
-                .call()
-                .await?;
+            let cluster_id = pr.get_cluster_id_by_peer_id(id_bytes.clone()).call().await?;
             if cluster_id != ZERO_CLUSTER_ID {
                 log::debug!("portal {portal_id} resolved via PortalRegistry");
                 return Ok(true);
             }
         }
         log::debug!("portal {portal_id} resolved via GatewayRegistry");
-        let strategy_addr = self
-            .gateway_registry
-            .get_used_strategy(id_bytes)
-            .block(latest_block)
-            .call()
-            .await?;
+        let strategy_addr = self.gateway_registry.get_used_strategy(id_bytes).call().await?;
         Ok(strategy_addr == self.default_strategy_addr)
     }
 
     async fn portal_clusters(&self, worker_id: U256) -> Result<Vec<PortalCluster>, ClientError> {
-        let latest_block = self.l2_client.get_block_number().await?;
-
-        // PortalRegistry: equal-split each active cluster's CUs across the active worker set.
+        // PortalRegistry: the contract returns the final CU value for each worker.
         let mut new_clusters: Vec<PortalCluster> = Vec::new();
         if let Some(pr) = &self.portal_registry {
-            let active_worker_count: U256 = self
-                .worker_registration
-                .get_active_worker_count()
-                .block(latest_block)
-                .call()
-                .await?;
-            if !active_worker_count.is_zero() {
-                let mut offset = U256::zero();
-                let limit = self.portals_per_page;
-                loop {
-                    let (cluster_ids, clusters, total_active) =
-                        pr.get_active_clusters(offset, limit).block(latest_block).call().await?;
-                    let page_len = clusters.len();
+            let mut offset = U256::zero();
+            let limit = self.portals_per_page;
+            loop {
+                let (cluster_ids, clusters, total_active) =
+                    pr.get_active_clusters(offset, limit).call().await?;
+                let page_len = clusters.len();
 
-                    let cluster_cus: Vec<U256> = if cluster_ids.is_empty() {
-                        Vec::new()
-                    } else {
-                        let mut mc = self.multicall().await?.block(latest_block);
-                        for cid in &cluster_ids {
-                            mc.add_call::<U256>(pr.method("getComputationUnits", *cid)?, false);
-                        }
-                        mc.call_array().await?
-                    };
-
-                    for (cluster, cus_total) in clusters.iter().zip(cluster_cus) {
-                        let per_worker = cus_total / active_worker_count;
-                        if per_worker.is_zero() {
-                            continue;
-                        }
-                        let portal_ids: Vec<PeerId> = cluster
-                            .portals
-                            .iter()
-                            .filter_map(|p| PeerId::from_bytes(&p.peer_id).ok())
-                            .collect();
-                        if portal_ids.is_empty() {
-                            continue;
-                        }
-                        new_clusters.push(PortalCluster {
-                            operator_addr: cluster.operator,
-                            portal_ids,
-                            allocated_computation_units: per_worker,
-                        });
+                let cluster_cus: Vec<U256> = if cluster_ids.is_empty() {
+                    Vec::new()
+                } else {
+                    let mut mc = self.multicall().await?;
+                    for cid in &cluster_ids {
+                        mc.add_call::<U256>(pr.method("getComputationUnits", *cid)?, false);
                     }
+                    mc.call_array().await?
+                };
 
-                    offset += U256::from(page_len);
-                    if page_len == 0 || offset >= total_active {
-                        break;
+                for (cluster, cus_total) in clusters.iter().zip(cluster_cus) {
+                    if cus_total.is_zero() {
+                        continue;
                     }
+                    let portal_ids: Vec<PeerId> = cluster
+                        .portals
+                        .iter()
+                        .filter_map(|p| PeerId::from_bytes(&p.peer_id).ok())
+                        .collect();
+                    if portal_ids.is_empty() {
+                        continue;
+                    }
+                    new_clusters.push(PortalCluster {
+                        operator_addr: cluster.operator,
+                        portal_ids,
+                        allocated_computation_units: cus_total,
+                    });
+                }
+
+                offset += U256::from(page_len);
+                if page_len == 0 || offset >= total_active {
+                    break;
                 }
             }
         }
@@ -892,7 +820,6 @@ impl Client for EthersClient {
             let allocations = self
                 .allocations_viewer
                 .get_allocations(worker_id, page.into(), self.portals_per_page)
-                .block(latest_block)
                 .call()
                 .await?;
             let page_size = U256::from(allocations.len());
@@ -910,17 +837,12 @@ impl Client for EthersClient {
         portal_id: PeerId,
     ) -> Result<Option<(String, Ratio<u128>)>, ClientError> {
         let id_bytes: Bytes = portal_id.to_bytes().into();
-        let latest_block = self.l2_client.get_block_number().await?;
 
         if let Some(pr) = &self.portal_registry {
-            let cluster_id = pr
-                .get_cluster_id_by_peer_id(id_bytes.clone())
-                .block(latest_block)
-                .call()
-                .await?;
+            let cluster_id = pr.get_cluster_id_by_peer_id(id_bytes.clone()).call().await?;
             if cluster_id != ZERO_CLUSTER_ID {
                 log::debug!("portal {portal_id} resolved via PortalRegistry");
-                let cluster = pr.get_cluster(cluster_id).block(latest_block).call().await?;
+                let cluster = pr.get_cluster(cluster_id).call().await?;
                 if !cluster.operator.is_zero() {
                     return Ok(Some((
                         cluster.operator.to_string(),
@@ -931,12 +853,12 @@ impl Client for EthersClient {
         }
 
         log::debug!("portal {portal_id} resolved via GatewayRegistry");
-        let portal = self.gateway_registry.get_gateway(id_bytes).block(latest_block).call().await?;
+        let portal = self.gateway_registry.get_gateway(id_bytes).call().await?;
         let operator: H160 = portal.operator;
         if operator.is_zero() {
             return Ok(None);
         }
-        let stake = self.gateway_registry.get_stake(operator).block(latest_block).call().await?;
+        let stake = self.gateway_registry.get_stake(operator).call().await?;
         Ok(Some((
             operator.to_string(),
             Ratio::new(stake.amount.as_u128(), SQD_DECIMALS_DENOM),

--- a/crates/contract-client/src/contracts.rs
+++ b/crates/contract-client/src/contracts.rs
@@ -15,8 +15,15 @@ abigen!(NetworkController, "abi/NetworkController.json");
 abigen!(Strategy, "abi/Strategy.json");
 abigen!(WorkerRegistration, "abi/WorkerRegistration.json");
 abigen!(AllocationsViewer, "abi/AllocationsViewer.json");
+abigen!(PortalRegistry, "abi/PortalRegistry.json");
 
 impl<T: Middleware> GatewayRegistry<T> {
+    pub fn get(client: Arc<T>, addr: Address) -> Self {
+        Self::new(addr, client)
+    }
+}
+
+impl<T: Middleware> PortalRegistry<T> {
     pub fn get(client: Arc<T>, addr: Address) -> Self {
         Self::new(addr, client)
     }

--- a/crates/contract-client/src/lib.rs
+++ b/crates/contract-client/src/lib.rs
@@ -18,6 +18,7 @@ mod cli;
 mod client;
 mod contracts;
 mod error;
+mod merge;
 mod transport;
 
 pub use ethers::types::{Address, U256};
@@ -25,6 +26,7 @@ pub use libp2p::PeerId;
 
 pub use cli::{Network, RpcArgs};
 pub use client::{
-    get_client, Allocation, Client, DummyData, EpochStream, NetworkNodes, NodeStream, PortalCluster, Worker,
+    get_client, Allocation, Client, DummyData, EpochStream, NetworkNodes, NodeStream,
+    PortalCluster, Worker,
 };
 pub use error::ClientError;

--- a/crates/contract-client/src/merge.rs
+++ b/crates/contract-client/src/merge.rs
@@ -1,0 +1,322 @@
+//! Pure helpers that combine PortalRegistry and legacy GatewayRegistry/AllocationsViewer reads
+//! into the trait-level shapes the rest of the network expects.
+//!
+//! Keeping the merge logic out of the async trait methods makes it unit-testable without RPC
+//! scaffolding. The async methods stay responsible for fetching; these functions only reshape.
+
+use std::collections::{BTreeMap, HashSet};
+
+use ethers::types::{Address, U256};
+use libp2p::PeerId;
+
+use crate::contracts;
+use crate::PortalCluster;
+
+/// Concatenate active portals from the new PortalRegistry and the legacy GatewayRegistry,
+/// preserving order within each source and de-duping by `PeerId`. New-source occurrences win
+/// position when the same peer ID appears in both (i.e. a migrated portal won't be double-listed
+/// and won't move to the legacy slot).
+pub(crate) fn merge_active_portals(
+    new_portals: Vec<PeerId>,
+    legacy_portals: Vec<PeerId>,
+) -> Vec<PeerId> {
+    let mut seen: HashSet<PeerId> = HashSet::new();
+    new_portals
+        .into_iter()
+        .chain(legacy_portals)
+        .filter(|p| seen.insert(*p))
+        .collect()
+}
+
+/// Merge new-registry clusters with legacy AllocationsViewer rows into the `Vec<PortalCluster>`
+/// shape downstream workers consume.
+///
+/// Invariant: **one `PortalCluster` per operator** in the output.
+///
+/// Steps:
+/// 1. Build the migrated peer-ID set from `new_clusters` (the union of every cluster's
+///    `portal_ids`).
+/// 2. Drop legacy allocations whose `gateway_id` is in that set — those portals are already
+///    served by the new registry, so re-counting them would double-allocate.
+/// 3. Insert new clusters into a `BTreeMap<Address, _>` keyed by operator. On collision:
+///    extend `portal_ids` (deduped) and add `allocated_computation_units` saturatingly.
+/// 4. Insert surviving legacy rows into the same map, preserving the old client behavior:
+///    append all portal IDs, but add only the first legacy `allocated` value per operator.
+/// 5. Return the map's values. `BTreeMap` iteration is by operator address ordering, giving
+///    callers a deterministic `Vec` for the same input.
+pub(crate) fn merge_portal_clusters(
+    new_clusters: Vec<PortalCluster>,
+    legacy_allocations: Vec<contracts::Allocation>,
+) -> Vec<PortalCluster> {
+    let migrated_peers: HashSet<PeerId> =
+        new_clusters.iter().flat_map(|c| c.portal_ids.iter().copied()).collect();
+
+    let mut by_operator: BTreeMap<Address, PortalCluster> = BTreeMap::new();
+    let mut legacy_cu_seen: HashSet<Address> = HashSet::new();
+
+    for cluster in new_clusters {
+        upsert_cluster(
+            &mut by_operator,
+            cluster.operator_addr,
+            cluster.portal_ids,
+            cluster.allocated_computation_units,
+        );
+    }
+
+    for allocation in legacy_allocations {
+        let Ok(peer_id) = PeerId::from_bytes(&allocation.gateway_id) else {
+            continue;
+        };
+        if migrated_peers.contains(&peer_id) {
+            continue;
+        }
+        upsert_legacy_allocation(
+            &mut by_operator,
+            &mut legacy_cu_seen,
+            allocation.operator,
+            peer_id,
+            allocation.allocated,
+        );
+    }
+
+    by_operator.into_values().collect()
+}
+
+/// Insert an additive cluster contribution into the operator-keyed map, deduping peer IDs and
+/// saturating CU sums so two `U256::MAX` rows never panic.
+fn upsert_cluster(
+    map: &mut BTreeMap<Address, PortalCluster>,
+    operator: Address,
+    portal_ids: Vec<PeerId>,
+    cus: U256,
+) {
+    map.entry(operator)
+        .and_modify(|existing| {
+            for pid in &portal_ids {
+                if !existing.portal_ids.contains(pid) {
+                    existing.portal_ids.push(*pid);
+                }
+            }
+            existing.allocated_computation_units =
+                existing.allocated_computation_units.saturating_add(cus);
+        })
+        .or_insert_with(|| PortalCluster {
+            operator_addr: operator,
+            portal_ids,
+            allocated_computation_units: cus,
+        });
+}
+
+/// Insert a legacy allocation while preserving the old first-CU-wins behavior per operator.
+fn upsert_legacy_allocation(
+    map: &mut BTreeMap<Address, PortalCluster>,
+    legacy_cu_seen: &mut HashSet<Address>,
+    operator: Address,
+    peer_id: PeerId,
+    cus: U256,
+) {
+    let contribution = if legacy_cu_seen.insert(operator) {
+        cus
+    } else {
+        U256::zero()
+    };
+    upsert_cluster(map, operator, vec![peer_id], contribution);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pid(seed: u8) -> PeerId {
+        // Deterministic PeerIds from a 32-byte seed via libp2p Ed25519 keypair derivation.
+        let bytes = [seed; 32];
+        let kp = libp2p::identity::Keypair::ed25519_from_bytes(bytes).unwrap();
+        kp.public().to_peer_id()
+    }
+
+    fn addr(seed: u8) -> Address {
+        let mut bytes = [0u8; 20];
+        bytes[19] = seed;
+        Address::from(bytes)
+    }
+
+    fn allocation(peer: PeerId, op: Address, cus: u64) -> contracts::Allocation {
+        contracts::Allocation {
+            gateway_id: ethers::types::Bytes::from(peer.to_bytes()),
+            allocated: U256::from(cus),
+            operator: op,
+        }
+    }
+
+    fn cluster(op: Address, peers: Vec<PeerId>, cus: u64) -> PortalCluster {
+        PortalCluster {
+            operator_addr: op,
+            portal_ids: peers,
+            allocated_computation_units: U256::from(cus),
+        }
+    }
+
+    // ---- merge_active_portals ----
+
+    #[test]
+    fn active_portals_both_empty_returns_empty() {
+        assert!(merge_active_portals(vec![], vec![]).is_empty());
+    }
+
+    #[test]
+    fn active_portals_legacy_only_passthrough() {
+        let legacy = vec![pid(1), pid(2), pid(3)];
+        assert_eq!(merge_active_portals(vec![], legacy.clone()), legacy);
+    }
+
+    #[test]
+    fn active_portals_new_only_passthrough() {
+        let new = vec![pid(1), pid(2)];
+        assert_eq!(merge_active_portals(new.clone(), vec![]), new);
+    }
+
+    #[test]
+    fn active_portals_overlap_dedupes_new_wins_position() {
+        // pid(2) is in both; it should appear once at the new-source position (index 1),
+        // not at the legacy position (index 3).
+        let new = vec![pid(1), pid(2), pid(3)];
+        let legacy = vec![pid(4), pid(5), pid(2), pid(6)];
+        let out = merge_active_portals(new, legacy);
+        assert_eq!(out, vec![pid(1), pid(2), pid(3), pid(4), pid(5), pid(6)]);
+    }
+
+    #[test]
+    fn active_portals_dedupes_within_new() {
+        let new = vec![pid(1), pid(2), pid(1), pid(3)];
+        let out = merge_active_portals(new, vec![]);
+        assert_eq!(out, vec![pid(1), pid(2), pid(3)]);
+    }
+
+    // ---- merge_portal_clusters ----
+
+    #[test]
+    fn clusters_both_empty_returns_empty() {
+        assert!(merge_portal_clusters(vec![], vec![]).is_empty());
+    }
+
+    #[test]
+    fn clusters_legacy_only_equal_strategy_one_operator_n_portals() {
+        // Legacy behavior: one operator can own several gateways backed by the same stake.
+        // Keep the first CU value and append all peer IDs.
+        let op = addr(1);
+        let legacy = vec![allocation(pid(1), op, 100), allocation(pid(2), op, 100)];
+        let out = merge_portal_clusters(vec![], legacy);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].operator_addr, op);
+        assert_eq!(out[0].portal_ids.len(), 2);
+        assert!(out[0].portal_ids.contains(&pid(1)));
+        assert!(out[0].portal_ids.contains(&pid(2)));
+        assert_eq!(out[0].allocated_computation_units, U256::from(100));
+    }
+
+    #[test]
+    fn clusters_legacy_only_different_allocations_keeps_first() {
+        let op = addr(1);
+        let legacy = vec![allocation(pid(1), op, 70), allocation(pid(2), op, 30)];
+        let out = merge_portal_clusters(vec![], legacy);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].allocated_computation_units, U256::from(70));
+    }
+
+    #[test]
+    fn clusters_legacy_row_for_migrated_peer_is_dropped() {
+        let op = addr(1);
+        let new = vec![cluster(op, vec![pid(1)], 500)];
+        let legacy = vec![allocation(pid(1), op, 999)];
+        let out = merge_portal_clusters(new, legacy);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].portal_ids, vec![pid(1)]);
+        // Legacy 999 dropped because pid(1) is migrated; only the new cluster's 500 remains.
+        assert_eq!(out[0].allocated_computation_units, U256::from(500));
+    }
+
+    #[test]
+    fn clusters_same_operator_in_both_sources_merges() {
+        let op = addr(1);
+        let new = vec![cluster(op, vec![pid(1)], 100)];
+        let legacy = vec![allocation(pid(2), op, 200)]; // not migrated
+        let out = merge_portal_clusters(new, legacy);
+        assert_eq!(out.len(), 1, "one PortalCluster per operator invariant");
+        assert!(out[0].portal_ids.contains(&pid(1)));
+        assert!(out[0].portal_ids.contains(&pid(2)));
+        assert_eq!(out[0].allocated_computation_units, U256::from(300));
+    }
+
+    #[test]
+    fn clusters_same_operator_adds_only_one_legacy_cu_to_new() {
+        let op = addr(1);
+        let new = vec![cluster(op, vec![pid(1)], 100)];
+        let legacy = vec![allocation(pid(2), op, 200), allocation(pid(3), op, 200)];
+        let out = merge_portal_clusters(new, legacy);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].portal_ids.contains(&pid(1)));
+        assert!(out[0].portal_ids.contains(&pid(2)));
+        assert!(out[0].portal_ids.contains(&pid(3)));
+        assert_eq!(out[0].allocated_computation_units, U256::from(300));
+    }
+
+    #[test]
+    fn clusters_two_new_clusters_same_operator_collapse() {
+        let op = addr(1);
+        let new = vec![cluster(op, vec![pid(1)], 100), cluster(op, vec![pid(2)], 200)];
+        let out = merge_portal_clusters(new, vec![]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].portal_ids.len(), 2);
+        assert_eq!(out[0].allocated_computation_units, U256::from(300));
+    }
+
+    #[test]
+    fn clusters_per_worker_cu_pass_through_single() {
+        let op = addr(1);
+        let new = vec![cluster(op, vec![pid(1)], 42)];
+        let out = merge_portal_clusters(new, vec![]);
+        assert_eq!(out[0].allocated_computation_units, U256::from(42));
+    }
+
+    #[test]
+    fn clusters_stable_iteration_order_by_operator() {
+        // Insert two operators in reverse-order; output must be sorted by Address (BTreeMap).
+        let op_a = addr(1);
+        let op_b = addr(2);
+        let new = vec![cluster(op_b, vec![pid(2)], 20), cluster(op_a, vec![pid(1)], 10)];
+        let out_first = merge_portal_clusters(new.clone(), vec![]);
+        let out_second = merge_portal_clusters(new, vec![]);
+        assert_eq!(out_first.len(), 2);
+        assert_eq!(out_first[0].operator_addr, op_a);
+        assert_eq!(out_first[1].operator_addr, op_b);
+        // PortalCluster has no PartialEq (stable public surface); compare via Debug.
+        assert_eq!(format!("{out_first:?}"), format!("{out_second:?}"), "deterministic ordering");
+    }
+
+    #[test]
+    fn clusters_two_new_cluster_cus_are_summed() {
+        let op = addr(1);
+        let new = vec![cluster(op, vec![pid(1)], u64::MAX), cluster(op, vec![pid(2)], u64::MAX)];
+        let mut out = merge_portal_clusters(new, vec![]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out.pop().unwrap().allocated_computation_units,
+            U256::from(u64::MAX).saturating_add(U256::from(u64::MAX))
+        );
+    }
+
+    #[test]
+    fn clusters_new_cu_sum_saturates_at_u256_max() {
+        let op = addr(1);
+        let new = vec![
+            PortalCluster {
+                operator_addr: op,
+                portal_ids: vec![pid(1)],
+                allocated_computation_units: U256::MAX,
+            },
+            cluster(op, vec![pid(2)], 1),
+        ];
+        let out = merge_portal_clusters(new, vec![]);
+        assert_eq!(out[0].allocated_computation_units, U256::MAX);
+    }
+}

--- a/crates/contract-client/src/merge.rs
+++ b/crates/contract-client/src/merge.rs
@@ -271,7 +271,7 @@ mod tests {
     }
 
     #[test]
-    fn clusters_per_worker_cu_pass_through_single() {
+    fn clusters_portal_registry_cu_passes_through() {
         let op = addr(1);
         let new = vec![cluster(op, vec![pid(1)], 42)];
         let out = merge_portal_clusters(new, vec![]);


### PR DESCRIPTION
Adds PortalRegistry support to `sqd-contract-client` so workers can read both the new PortalRegistry and the legacy GatewayRegistry.
The new path is PortalRegistry-first for migrated portals, with GatewayRegistry fallback for unmigrated gateways. Active portal enumeration returns the union of both registries.