### PR TITLE
docs: sharpen README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,109 @@
 # SQD Network
 
-This is a libp2p-based network that allows communication between nodes. See
-[this page](https://github.com/subsquid/subsquid-network-contracts/wiki/Network-architecture)
-for the network architecture.
+Rust implementation of the peer-to-peer layer of SQD Network, the decentralized
+data lake behind [SQD](https://sqd.dev). Nodes communicate over
+[libp2p](https://github.com/libp2p/rust-libp2p), exchanging queries, query
+results, heartbeats, and logs. For the network design, see the
+[network architecture wiki](https://github.com/subsquid/subsquid-network-contracts/wiki/Network-architecture)
+and the [SQD Network docs](https://docs.sqd.dev/en/network).
 
-## Transport crate
+## How it fits into SQD
 
-Contains the implementation of the libp2p transport protocol for the network.
-It exposes the simple API for the following predefined actors on the network.
+SQD Network stores blockchain data as chunks distributed across worker nodes.
+A scheduler assigns chunks to workers; portals route client queries to the
+workers that hold the relevant data and collect the results. SQD Portal, the
+data API over 200+ chains, is built on top of this network. This repository
+provides the transport protocol, message formats, and a few supporting node
+binaries used by those actors.
 
-### Worker
+## Node roles
 
-Most nodes on the network are workers. Their main purpose is to process queries
-from the Gateways.
+The transport layer exposes APIs for the predefined actors on the network:
 
-### Scheduler
+- **Worker**: holds data chunks and answers queries routed to it.
+- **Scheduler**: assigns chunks to workers based on collected heartbeats and
+  distributes the assignments.
+- **Portal**: entry point for clients. It sends queries to workers and
+  collects responses. (Previously called Gateway.)
+- **Pings collector**: collects worker heartbeats and stores them.
+- **Logs collector**: persists query logs received from workers for analysis.
 
-The Scheduler is a centralized controller of data distribution on the network.
-It assigns chunks to workers based on collected pings and sends them the
-assignments.
+## Workspace layout
 
-### Gateway
+This is a Cargo workspace (`crates/*`).
 
-The Gateway is the entry point for the clients. It sends queries to the Workers
-and receives the responses.
+| Crate | Type | Description |
+|---|---|---|
+| `sqd-network-transport` | library | libp2p transport and per-actor behaviours. Actors are gated behind Cargo features (`worker`, `portal`, `observer`, `pings-collector`, `logs-collector`, `portal-logs-collector`, `sql-client`). |
+| `sqd-messages` | library | Protobuf (prost) message schemas for inter-node communication. Source schema: `crates/messages/proto/messages.proto`. |
+| `sqd-assignments` | library | FlatBuffers chunk-assignment format with `builder` and `reader` features. Schema: `crates/assignments/schema/assignment.fbs`. |
+| `sqd-contract-client` | library | Reads onchain registries, allocations, and node sets from the network's smart contracts over an RPC node ([ethers](https://github.com/gakonst/ethers-rs)). |
+| `sqd-bootnode` | binary | Minimal node that helps new nodes discover peers and bootstrap into the network. |
+| `sqd-keygen` | binary | Generates a libp2p keypair for a node and prints its peer ID. |
+| `sqd-observer` | binary | Joins the network, observes gossip and peers, and exposes Prometheus metrics over HTTP. |
 
-### Logs Collector
+## Build
 
-The Logs Collector saves the logs it receives to the persistent database for
-further analysis.
-
-### Pings Collector
-
-The Pings Collector instances collect broadcasted pings from the Workers and
-store them in the database.
-
-## Messages crate
-
-Contains protobuf schemas for the messages exchanged between nodes.
-
-## Keygen
-
-A simple binary for generating a keypair for a node.
-
-The simplest way to use it is by using Docker. The following command will
-generate a keypair and save it to the `key` file in the current directory, or
-print the peer id if the file already exists.
+Requires the Rust toolchain pinned in `rust-toolchain` (1.89.0) and
+`protoc` (protobuf-compiler) for building `sqd-messages`.
 
 ```bash
-docker run -u $(id -u):$(id -g) -v .:/host subsquid/keygen:tethys /host/key
+cargo build --release
 ```
 
-## Bootnode
+Build a specific binary:
 
-The simplest possible node which acts as a source of information about other
-nodes. It is used by new nodes to connect to the network.
+```bash
+cargo build --release --bin sqd-bootnode
+cargo build --release --bin sqd-keygen
+cargo build --release --bin sqd-observer
+```
 
-## Contract Client
+The transport library compiles only the actor APIs you enable. For example, to
+build with the worker actor:
 
-A client for interacting with the smart contracts through the RPC node.
+```bash
+cargo build -p sqd-network-transport --features worker
+```
+
+## Docker
+
+The `Dockerfile` builds the three binaries and provides image targets for
+`bootnode`, `keygen`, and `observer`. The published images are
+`subsquid/bootnode`, `subsquid/keygen`, and `subsquid/observer`.
+
+## Run
+
+### Keygen
+
+Generate a keypair and write it to a `key` file in the current directory, or
+print the peer ID if the file already exists:
+
+```bash
+docker run -u $(id -u):$(id -g) -v .:/host subsquid/keygen:latest /host/key
+```
+
+### Bootnode and observer
+
+Both nodes share the transport CLI flags (also settable via environment
+variables):
+
+| Flag | Env | Description |
+|---|---|---|
+| `--key` | `KEY_PATH` | Path to the libp2p key file. |
+| `--p2p-listen-addrs` | `P2P_LISTEN_ADDRS` | Multiaddrs the node listens on. |
+| `--p2p-public-addrs` | `P2P_PUBLIC_ADDRS` | Public multiaddrs the node advertises. |
+| `--boot-nodes` | `BOOT_NODES` | Boot nodes as `<peer_id> <address>` entries. |
+| `--rpc-url` | `RPC_URL` | RPC node URL for reading network contracts. |
+
+The observer additionally takes `--port` (HTTP port for metrics, default 8000)
+and `--network` (`mainnet` or `tethys`).
+
+## Documentation
+
+- SQD Network: https://docs.sqd.dev/en/network
+- SQD: https://sqd.dev
+
+## License
+
+AGPL-3.0-or-later. See [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
## Summary

Rewrote the README to be sharper and more accurate against the actual workspace and source, without growing it for its own sake.

## What changed and why

The previous README listed actors and crates that no longer match the code (e.g. "Transport crate / Messages crate" prose, "Gateway" rather than the current Portal terminology) and omitted several crates that exist today.

The new README is verified against:
- **Cargo workspace** (`Cargo.toml`, `crates/*/Cargo.toml`): seven crates documented exactly as named: `sqd-network-transport`, `sqd-messages`, `sqd-assignments`, `sqd-contract-client`, `sqd-bootnode`, `sqd-keygen`, `sqd-observer`.
- **`crates/transport/src`**: actor list and the Cargo feature gates (`worker`, `portal`, `observer`, `pings-collector`, `logs-collector`, `portal-logs-collector`, `sql-client`) taken from `Cargo.toml [features]` and `lib.rs` exports.
- **`crates/messages/proto/messages.proto`** and `build.rs`: confirms prost/protobuf schemas and the Worker/Scheduler/Portal/collector message flow (the proto comments call the role Portal, previously Gateway).
- **`crates/assignments/schema/assignment.fbs`** and `lib.rs`: FlatBuffers assignment format with `builder`/`reader` features.
- **`crates/contract-client/src`**: reads onchain registries/allocations over an RPC node via ethers.
- **`Dockerfile`** and `.github/workflows/docker.yml`: build targets and the three published images (`subsquid/bootnode`, `subsquid/keygen`, `subsquid/observer`); kept the keygen Docker example, updated the tag to `:latest` (confirmed present on Docker Hub).
- **CLI flags** from `crates/transport/src/cli.rs` and `crates/observer/src/cli.rs` for the Configuration table.
- **`rust-toolchain`** (1.89.0) and the `protobuf-compiler` build dependency from the Dockerfile.
- **License**: all crates declare `AGPL-3.0-or-later`; root `LICENSE.md` is AGPLv3. License line updated to match.

Crates are not published to crates.io (verified 404 in the sparse index), so no crates.io links were added.

## Style compliance

- No marketing words, no em dashes, no emojis.
- "onchain" written as one word.
- Every link verified returning 200: docs.sqd.dev/en/network, sqd.dev, the network-architecture wiki, rust-libp2p, ethers-rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)