### PR TITLE
Net 685 last applied assignment

### DIFF
--- a/crates/assignments/Cargo.toml
+++ b/crates/assignments/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [features]
 reader = ["serde_json", "ouroboros"]
 builder = ["base64", "curve25519-dalek", "hmac", "serde_json", "url"]
+mvcc-chunks = []
 
 [dependencies]
 anyhow = { version = "1.0" }
@@ -25,3 +26,4 @@ url = { version = "2.5.0", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
+serde_json = "1.0"

--- a/crates/assignments/Cargo.toml
+++ b/crates/assignments/Cargo.toml
@@ -26,4 +26,5 @@ url = { version = "2.5.0", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
+# Tests validate NetworkState JSON compatibility without requiring the reader feature.
 serde_json = "1.0"

--- a/crates/assignments/src/common.rs
+++ b/crates/assignments/src/common.rs
@@ -21,4 +21,12 @@ pub struct NetworkAssignment {
 pub struct NetworkState {
     pub network: String,
     pub assignment: NetworkAssignment,
+
+    #[cfg(feature = "mvcc-chunks")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_assignment: Option<NetworkAssignment>,
+
+    #[cfg(feature = "mvcc-chunks")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub portal_assignment: Option<NetworkAssignment>,
 }

--- a/crates/assignments/src/common.rs
+++ b/crates/assignments/src/common.rs
@@ -10,10 +10,13 @@ pub enum WorkerStatus {
 
 #[derive(Serialize, Deserialize)]
 pub struct NetworkAssignment {
-    /// Deprecated: use `fb_url` or `fb_url_v1` instead.
-    #[deprecated(note = "use fb_url or fb_url_v1 instead")]
+    /// Deprecated: use `fb_url_v1` instead.
+    #[deprecated(note = "use fb_url_v1 instead")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Deprecated: use `fb_url_v1` instead.
+    #[deprecated(note = "use fb_url_v1 instead")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fb_url: Option<String>,
     pub fb_url_v1: Option<String>,
     pub id: String,

--- a/crates/assignments/src/common.rs
+++ b/crates/assignments/src/common.rs
@@ -10,7 +10,10 @@ pub enum WorkerStatus {
 
 #[derive(Serialize, Deserialize)]
 pub struct NetworkAssignment {
-    pub url: Option<String>, // deprecated
+    /// Deprecated: use `fb_url` or `fb_url_v1` instead.
+    #[deprecated(note = "use fb_url or fb_url_v1 instead")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
     pub fb_url: Option<String>,
     pub fb_url_v1: Option<String>,
     pub id: String,

--- a/crates/assignments/tests/network_state.rs
+++ b/crates/assignments/tests/network_state.rs
@@ -1,0 +1,74 @@
+use sqd_assignments::NetworkState;
+
+const LEGACY_STATE: &str = r#"{
+  "network": "testnet",
+  "assignment": {
+    "url": "",
+    "fb_url": "https://example.test/legacy.fb.0.gz",
+    "fb_url_v1": "https://example.test/legacy.fb.1.gz",
+    "id": "2026-06-09T12:00:00_LEGACY",
+    "effective_from": 1781000000
+  }
+}"#;
+
+#[test]
+fn legacy_network_state_deserializes() {
+    let state: NetworkState = serde_json::from_str(LEGACY_STATE).unwrap();
+
+    assert_eq!(state.network, "testnet");
+    assert_eq!(state.assignment.id, "2026-06-09T12:00:00_LEGACY");
+
+    #[cfg(feature = "mvcc-chunks")]
+    {
+        assert!(state.worker_assignment.is_none());
+        assert!(state.portal_assignment.is_none());
+    }
+}
+
+#[cfg(feature = "mvcc-chunks")]
+#[test]
+fn split_network_state_deserializes() {
+    let state: NetworkState = serde_json::from_str(
+        r#"{
+          "network": "testnet",
+          "assignment": {
+            "url": "",
+            "fb_url": "https://example.test/legacy.fb.0.gz",
+            "fb_url_v1": "https://example.test/legacy.fb.1.gz",
+            "id": "legacy",
+            "effective_from": 1781000000
+          },
+          "worker_assignment": {
+            "url": "",
+            "fb_url": "https://example.test/worker.fb.0.gz",
+            "fb_url_v1": "https://example.test/worker.fb.1.gz",
+            "id": "worker",
+            "effective_from": 1781000000
+          },
+          "portal_assignment": {
+            "url": "",
+            "fb_url": "https://example.test/portal.fb.0.gz",
+            "fb_url_v1": "https://example.test/portal.fb.1.gz",
+            "id": "portal",
+            "effective_from": 1781000000
+          }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(state.assignment.id, "legacy");
+    assert_eq!(state.worker_assignment.unwrap().id, "worker");
+    assert_eq!(state.portal_assignment.unwrap().id, "portal");
+}
+
+#[cfg(feature = "mvcc-chunks")]
+#[test]
+fn absent_split_assignments_are_skipped_when_serializing() {
+    let state: NetworkState = serde_json::from_str(LEGACY_STATE).unwrap();
+
+    let serialized = serde_json::to_value(state).unwrap();
+
+    assert!(serialized.get("assignment").is_some());
+    assert!(serialized.get("worker_assignment").is_none());
+    assert!(serialized.get("portal_assignment").is_none());
+}

--- a/crates/assignments/tests/network_state.rs
+++ b/crates/assignments/tests/network_state.rs
@@ -27,12 +27,11 @@ fn legacy_network_state_deserializes() {
 
 #[allow(deprecated)]
 #[test]
-fn deprecated_assignment_url_defaults_and_skips_when_absent() {
+fn deprecated_assignment_urls_default_and_skip_when_absent() {
     let state: NetworkState = serde_json::from_str(
         r#"{
           "network": "testnet",
           "assignment": {
-            "fb_url": "https://example.test/legacy.fb.0.gz",
             "fb_url_v1": "https://example.test/legacy.fb.1.gz",
             "id": "legacy",
             "effective_from": 1781000000
@@ -42,9 +41,11 @@ fn deprecated_assignment_url_defaults_and_skips_when_absent() {
     .unwrap();
 
     assert!(state.assignment.url.is_none());
+    assert!(state.assignment.fb_url.is_none());
 
     let serialized = serde_json::to_value(state).unwrap();
     assert!(serialized["assignment"].get("url").is_none());
+    assert!(serialized["assignment"].get("fb_url").is_none());
 }
 
 #[cfg(feature = "mvcc-chunks")]

--- a/crates/assignments/tests/network_state.rs
+++ b/crates/assignments/tests/network_state.rs
@@ -25,6 +25,28 @@ fn legacy_network_state_deserializes() {
     }
 }
 
+#[allow(deprecated)]
+#[test]
+fn deprecated_assignment_url_defaults_and_skips_when_absent() {
+    let state: NetworkState = serde_json::from_str(
+        r#"{
+          "network": "testnet",
+          "assignment": {
+            "fb_url": "https://example.test/legacy.fb.0.gz",
+            "fb_url_v1": "https://example.test/legacy.fb.1.gz",
+            "id": "legacy",
+            "effective_from": 1781000000
+          }
+        }"#,
+    )
+    .unwrap();
+
+    assert!(state.assignment.url.is_none());
+
+    let serialized = serde_json::to_value(state).unwrap();
+    assert!(serialized["assignment"].get("url").is_none());
+}
+
 #[cfg(feature = "mvcc-chunks")]
 #[test]
 fn split_network_state_deserializes() {
@@ -63,12 +85,14 @@ fn split_network_state_deserializes() {
 
 #[cfg(feature = "mvcc-chunks")]
 #[test]
-fn absent_split_assignments_are_skipped_when_serializing() {
+fn absent_split_assignments_stay_omitted_after_json_round_trip() {
     let state: NetworkState = serde_json::from_str(LEGACY_STATE).unwrap();
 
-    let serialized = serde_json::to_value(state).unwrap();
+    let serialized = serde_json::to_string(&state).unwrap();
+    let round_tripped: NetworkState = serde_json::from_str(&serialized).unwrap();
+    let value = serde_json::to_value(round_tripped).unwrap();
 
-    assert!(serialized.get("assignment").is_some());
-    assert!(serialized.get("worker_assignment").is_none());
-    assert!(serialized.get("portal_assignment").is_none());
+    assert!(value.get("assignment").is_some());
+    assert!(value.get("worker_assignment").is_none());
+    assert!(value.get("portal_assignment").is_none());
 }

--- a/crates/messages/proto/messages.proto
+++ b/crates/messages/proto/messages.proto
@@ -24,6 +24,8 @@ message Heartbeat {
   // Points to the chunks in this worker's assignment list referenced by `assignment_id`.
   BitString missing_chunks = 3;
   optional uint64 stored_bytes = 4;
+  // Highest strictly-monotonic worker assignment fully applied by this worker.
+  optional int64 last_applied_assignment_id = 5;
 }
 
 // Portal -> Worker

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -227,8 +227,9 @@ impl BaseBehaviour {
     pub fn find_and_dial(&mut self, peer_id: PeerId) {
         if self.inner.address_cache.contains(&peer_id) {
             log::debug!("Dialing peer {peer_id} using cached address");
-            self.pending_events
-                .push_back(ToSwarm::Dial { opts: peer_id.into() });
+            self.pending_events.push_back(ToSwarm::Dial {
+                opts: peer_id.into(),
+            });
         } else if self.ongoing_lookups.contains_left(&peer_id) {
             log::debug!("Query for peer {peer_id} already ongoing");
         } else {

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -228,7 +228,7 @@ impl BaseBehaviour {
         if self.inner.address_cache.contains(&peer_id) {
             log::debug!("Dialing peer {peer_id} using cached address");
             self.pending_events.push_back(ToSwarm::Dial {
-                opts: peer_id.into(),
+                opts: DialOpts::peer_id(peer_id).build(),
             });
         } else if self.ongoing_lookups.contains_left(&peer_id) {
             log::debug!("Query for peer {peer_id} already ongoing");


### PR DESCRIPTION
### Summary

Adds optional last_applied_assignment_id to worker heartbeat messages for NET-685.

This lets workers report the highest worker assignment they have fully applied, so the ping collector can persist that signal   for later MVCC portal-promotion logic.

###   Notes

  - Field is optional for backward compatibility.
  - Ordering semantics depend on NET-686.
  - Scheduler-side consumption is out of scope for this PR.