### PR TITLE
[net-685] last applied assignment in heartbeat message

### DIFF
--- a/crates/messages/proto/messages.proto
+++ b/crates/messages/proto/messages.proto
@@ -25,6 +25,8 @@ message Heartbeat {
   BitString missing_chunks = 3;
   optional uint64 stored_bytes = 4;
   optional uint32 current_epoch = 5;  // latest on-chain epoch known to the worker
+  // Highest strictly-monotonic worker assignment fully applied by this worker.
+  optional int64 last_applied_assignment_id = 6;
 }
 
 // Portal -> Worker


### PR DESCRIPTION
### Summary

Adds optional last_applied_assignment_id to worker heartbeat messages for NET-685.

This lets workers report the highest worker assignment they have fully applied, so the ping collector can persist that signal for later MVCC portal-promotion logic.

###   Notes

  - Field is optional for backward compatibility.
  - Uses proto field number 6; field 5 is already used by current_epoch.
  - Ordering semantics depend on NET-686.
  - Scheduler-side consumption is out of scope for this PR.

###   Validation

  - cargo test -p sqd-messages