### PR TITLE
[net-685] last applied assignment in messages

### DIFF
--- a/crates/contract-client/src/transport.rs
+++ b/crates/contract-client/src/transport.rs
@@ -66,7 +66,10 @@ impl Transport {
     /// Without a timeout an HTTP request whose connection is accepted but never
     /// answered (a stalled node, a black-holing load balancer) hangs forever,
     /// which can wedge polling loops that `await` these calls inline.
-    pub async fn connect(rpc_url: &str, timeout: Duration) -> Result<Arc<Provider<Self>>, ClientError> {
+    pub async fn connect(
+        rpc_url: &str,
+        timeout: Duration,
+    ) -> Result<Arc<Provider<Self>>, ClientError> {
         let transport = if rpc_url.starts_with("http") {
             let client = reqwest::Client::builder().timeout(timeout).build()?;
             Self::Http(Http::new_with_client(Url::parse(rpc_url)?, client))

--- a/crates/messages/proto/messages.proto
+++ b/crates/messages/proto/messages.proto
@@ -25,6 +25,8 @@ message Heartbeat {
   BitString missing_chunks = 3;
   optional uint64 stored_bytes = 4;
   optional uint32 current_epoch = 5;  // latest on-chain epoch known to the worker
+  // Highest worker assignment fully applied by this worker. Opaque outside the scheduler.
+  optional string last_applied_assignment_id = 6;
 }
 
 // Portal -> Worker


### PR DESCRIPTION
### Summary

Adds optional last_applied_assignment_id to worker heartbeat messages for NET-685.

This lets workers report the highest worker assignment they have fully applied, so the ping collector can persist that signal for later MVCC portal-promotion logic.

###   Notes

  - Field is optional for backward compatibility.
  - Field type is string; the value is opaque to workers, portals, and network-components.
  - Uses proto field number 6; field 5 is already used by current_epoch.
  - Assignment ordering is scheduler-owned and handled separately under NET-686.
  - Scheduler-side consumption is out of scope for this PR.

###   Validation

  - cargo test -p sqd-messages