### PR TITLE
Fix unreachable workers in pings collector NET-384

### DIFF
--- a/crates/contract-client/src/client.rs
+++ b/crates/contract-client/src/client.rs
@@ -206,7 +206,7 @@ pub async fn get_client(rpc_args: &RpcArgs) -> Result<Box<dyn Client>, ClientErr
 }
 
 /// Dummy data structure loaded from JSON file
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct DummyData {
     pub current_epoch: u32,
     pub current_epoch_start: u64,
@@ -237,8 +237,10 @@ pub struct DummyPortalCluster {
     pub allocated_computation_units: String,
 }
 
+/// In-memory [`Client`] backed by static data. Used by `--dummy-client-file-path` and as a
+/// stand-in for the on-chain client in tests.
 #[derive(Clone)]
-struct DummyClient {
+pub struct DummyClient {
     data: DummyData,
 }
 

--- a/crates/contract-client/src/lib.rs
+++ b/crates/contract-client/src/lib.rs
@@ -30,7 +30,7 @@ pub use libp2p::PeerId;
 
 pub use cli::{Network, RpcArgs};
 pub use client::{
-    get_client, Allocation, Client, DummyData, EpochStream, NetworkNodes, NodeStream,
+    get_client, Allocation, Client, DummyClient, DummyData, EpochStream, NetworkNodes, NodeStream,
     PortalCluster, Worker,
 };
 pub use error::ClientError;

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -607,6 +607,12 @@ fn stale_addrs(current: Vec<Multiaddr>, announced: &HashSet<Multiaddr>) -> Vec<M
 
 #[cfg(test)]
 mod tests {
+    use libp2p::{
+        core::{transport::PortUse, Endpoint},
+        swarm::ConnectionId,
+    };
+    use sqd_contract_client::{DummyClient, DummyData};
+
     use super::*;
 
     fn addr(port: u16, peer: PeerId) -> Multiaddr {
@@ -635,5 +641,121 @@ mod tests {
         let current = vec![addr(1000, peer), addr(2000, peer)];
         let announced = HashSet::from([addr(1000, peer), addr(2000, peer)]);
         assert!(stale_addrs(current, &announced).is_empty());
+    }
+
+    /// Async because `WhitelistBehavior::new` builds a `tokio::time::interval` stream, which
+    /// panics without a reactor.
+    fn test_behaviour(keypair: &Keypair) -> BaseBehaviour {
+        let config = BaseConfig {
+            // Pinned rather than read from the environment: `ONCHAIN_UPDATE_INTERVAL_SEC=0` or
+            // `ADDR_CACHE_SIZE=0` in a developer's shell would otherwise panic the test.
+            onchain_update_interval: Duration::from_secs(60),
+            addr_cache_size: NonZeroUsize::new(16).expect("non-zero"),
+            ..BaseConfig::from_env()
+        };
+        BaseBehaviour::new(
+            keypair,
+            Box::new(DummyClient::new(DummyData::default())),
+            config,
+            vec![],
+            StreamProtocol::new("/subsquid/dht/test/1.0.0"),
+            AgentInfo {
+                name: "test",
+                version: "0.0.0",
+            },
+        )
+    }
+
+    /// `keypair` must be the *remote* peer's, so `public_key` and `peer_id` agree as they do on
+    /// the wire.
+    fn identify_received(keypair: &Keypair, listen_addrs: Vec<Multiaddr>) -> identify::Event {
+        identify::Event::Received {
+            connection_id: ConnectionId::new_unchecked(1),
+            peer_id: keypair.public().to_peer_id(),
+            info: identify::Info {
+                public_key: keypair.public(),
+                protocol_version: ID_PROTOCOL.to_owned(),
+                agent_version: "sqd-worker/2.13.0".to_owned(),
+                listen_addrs,
+                protocols: vec![],
+                observed_addr: "/ip4/5.6.7.8/udp/1/quic-v1".parse().expect("valid addr"),
+                signed_peer_record: None,
+            },
+        }
+    }
+
+    /// A worker behind NAT announces a public address that no longer reaches it, while we are
+    /// connected on a different address learned from the DHT. The announced set must not be
+    /// treated as authoritative: the address we are demonstrably connected on has to survive in
+    /// the routing stores, or the worker becomes permanently undialable (NET-384).
+    ///
+    /// Asserted against the address cache and the Kademlia routing table individually rather than
+    /// against the aggregate of `InnerBehaviour`, because `autonat` keeps its own transient copy
+    /// of a connected peer's address and would mask the defect.
+    #[tokio::test]
+    async fn keeps_confirmed_address_when_peer_announces_a_stale_one() {
+        let local = Keypair::generate_ed25519();
+        let remote = Keypair::generate_ed25519();
+        let peer = remote.public().to_peer_id();
+        let working = addr(12208, peer); // the address the connection actually runs on
+        let announced = addr(9999, peer); // the stale address the worker advertises
+
+        let mut behaviour = test_behaviour(&local);
+        // Stand in for the on-chain registration that normally whitelists a worker.
+        behaviour.allow_peer(peer);
+
+        // The DHT lookup that found this worker is what put `working` in the routing table.
+        behaviour.inner.kademlia.add_address(&peer, working.clone());
+
+        // The dial succeeded on `working`, so it is confirmed reachable.
+        behaviour
+            .inner()
+            .handle_established_outbound_connection(
+                ConnectionId::new_unchecked(1),
+                peer,
+                &working,
+                Endpoint::Dialer,
+                PortUse::Reuse,
+            )
+            .expect("connection should be accepted");
+
+        // Identify arrives over that same connection, announcing only the stale address.
+        behaviour.on_identify_event(identify_received(&remote, vec![announced.clone()]));
+
+        let cached = behaviour
+            .inner
+            .address_cache
+            .handle_pending_outbound_connection(
+                ConnectionId::new_unchecked(2),
+                Some(peer),
+                &[],
+                Endpoint::Dialer,
+            )
+            .expect("dial should be allowed");
+        let routed = behaviour
+            .inner
+            .kademlia
+            .handle_pending_outbound_connection(
+                ConnectionId::new_unchecked(3),
+                Some(peer),
+                &[],
+                Endpoint::Dialer,
+            )
+            .expect("dial should be allowed");
+
+        // Guards against the test passing vacuously if the identify event stops being applied.
+        assert!(
+            routed.contains(&announced),
+            "identify was not applied: kademlia never learned the announced address"
+        );
+
+        assert!(
+            cached.contains(&working),
+            "address cache dropped the address we are connected on; it would dial {cached:?}"
+        );
+        assert!(
+            routed.contains(&working),
+            "kademlia dropped the address we are connected on; it would dial {routed:?}"
+        );
     }
 }

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -22,7 +22,7 @@ use libp2p::{
         dial_opts::{DialOpts, PeerCondition},
         ConnectionClosed, FromSwarm, NetworkBehaviour, ToSwarm,
     },
-    Multiaddr, StreamProtocol,
+    StreamProtocol,
 };
 use libp2p_swarm_derive::NetworkBehaviour;
 use serde::{Deserialize, Serialize};
@@ -396,40 +396,12 @@ impl BaseBehaviour {
             _ => return None,
         };
 
-        // Filter out unreachable (private) addresses and normalize the rest to fully-qualified
-        // /p2p addresses, matching what `kademlia.add_address`/`remove_address` store internally.
-        let listen_addrs: HashSet<Multiaddr> = listen_addrs
-            .into_iter()
-            .filter(addr_is_reachable)
-            .filter_map(|addr| addr.with_p2p(peer_id).ok())
-            .collect();
-
-        // A peer may briefly announce no reachable addresses (e.g. mid-restart, before AutoNAT
-        // confirms a public address) — don't wipe its existing entry in that case.
-        if !listen_addrs.is_empty() {
-            // Add the freshly announced addresses first, then prune whatever the peer no longer
-            // announces. This order guarantees we never try to remove the entry's last address
-            // (which would evict the whole peer, not just the address).
-            for addr in &listen_addrs {
-                self.inner.kademlia.add_address(&peer_id, addr.clone());
-            }
-            let current_addrs = match self.inner.kademlia.kbucket(peer_id) {
-                Some(bucket) => bucket
-                    .iter()
-                    .find(|entry| *entry.node.key.preimage() == peer_id)
-                    .map(|entry| entry.node.value.iter().cloned().collect::<Vec<_>>())
-                    .unwrap_or_default(),
-                None => Vec::new(),
-            };
-            for addr in stale_addrs(current_addrs, &listen_addrs) {
-                log::debug!("Removing stale address of {peer_id}: {addr}");
-                self.inner.kademlia.remove_address(&peer_id, &addr);
-            }
-
-            // Replace (not extend) the cached address set, so it too drops migrated-away addrs.
-            self.inner.address_cache.evict(peer_id);
-            self.inner.address_cache.put(peer_id, listen_addrs);
-        }
+        // Filter out unreachable (private) addresses and add the remaining to cache and DHT
+        let listen_addrs = listen_addrs.into_iter().filter(addr_is_reachable);
+        self.inner.address_cache.put(peer_id, listen_addrs.clone());
+        listen_addrs.clone().for_each(|addr| {
+            self.inner.kademlia.add_address(&peer_id, addr);
+        });
 
         self.identified_peers.insert(peer_id);
         self.try_emit_confidence()
@@ -599,17 +571,12 @@ impl BaseBehaviour {
     }
 }
 
-/// Addresses present in `current` but absent from `announced`. Used to prune routing-table
-/// entries down to what a peer's latest identify announcement actually claims.
-fn stale_addrs(current: Vec<Multiaddr>, announced: &HashSet<Multiaddr>) -> Vec<Multiaddr> {
-    current.into_iter().filter(|addr| !announced.contains(addr)).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use libp2p::{
         core::{transport::PortUse, Endpoint},
         swarm::ConnectionId,
+        Multiaddr,
     };
     use sqd_contract_client::{DummyClient, DummyData};
 
@@ -617,30 +584,6 @@ mod tests {
 
     fn addr(port: u16, peer: PeerId) -> Multiaddr {
         format!("/ip4/1.2.3.4/udp/{port}/quic-v1/p2p/{peer}").parse().unwrap()
-    }
-
-    #[test]
-    fn no_stale_addrs_when_announced_is_superset() {
-        let peer = PeerId::random();
-        let current = vec![addr(1000, peer)];
-        let announced = HashSet::from([addr(1000, peer), addr(2000, peer)]);
-        assert!(stale_addrs(current, &announced).is_empty());
-    }
-
-    #[test]
-    fn detects_stale_addr_after_port_migration() {
-        let peer = PeerId::random();
-        let current = vec![addr(1000, peer), addr(2000, peer)];
-        let announced = HashSet::from([addr(2000, peer)]);
-        assert_eq!(stale_addrs(current, &announced), vec![addr(1000, peer)]);
-    }
-
-    #[test]
-    fn identical_sets_produce_no_stale_addrs() {
-        let peer = PeerId::random();
-        let current = vec![addr(1000, peer), addr(2000, peer)];
-        let announced = HashSet::from([addr(1000, peer), addr(2000, peer)]);
-        assert!(stale_addrs(current, &announced).is_empty());
     }
 
     /// Async because `WhitelistBehavior::new` builds a `tokio::time::interval` stream, which


### PR DESCRIPTION
Commit 292e67f introduced a regression. Pruning the existing cached addresses sometimes drops reachable ones, replacing them with unreachable ones.

The Identify response reports `listen_addrs` advertised by the peer. They may differ from the address the peer was actually dialed on (e.g., the worker manually overwrites the address through the config). In this case, the address from Identify replaces the correct address in both the **cache** and **Kademlia** local store. The peer is then not reachable for 20-100 minutes because no reachable addresses are stored for it.

In this PR:
- Added a test showing the behaviour when Identify announces an incorrect address. The test fails before the fix.
- Reverted 292e67f — multiple addresses in DHT are never a problem because they all are dialed simultaneously.