### PR TITLE
Run lookups after dial failure NET-384

### DIFF
--- a/crates/transport/src/behaviour/addr_cache.rs
+++ b/crates/transport/src/behaviour/addr_cache.rs
@@ -149,6 +149,9 @@ mod tests {
 
     #[test]
     fn put_with_no_reachable_addrs_does_not_create_entry() {
+        // Loopback counts as reachable while `PRIVATE_NETWORK` is set, so this test cannot run
+        // alongside the one that sets it.
+        let _guard = crate::util::private_network_env_lock();
         let mut cache = cache();
         let peer = PeerId::random();
 

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -575,8 +575,8 @@ impl BaseBehaviour {
 mod tests {
     use libp2p::{
         core::{transport::PortUse, Endpoint},
-        swarm::ConnectionId,
-        Multiaddr,
+        swarm::{ConnectionId, DialError, DialFailure},
+        Multiaddr, TransportError,
     };
     use sqd_contract_client::{DummyClient, DummyData};
 
@@ -699,6 +699,120 @@ mod tests {
         assert!(
             routed.contains(&working),
             "kademlia dropped the address we are connected on; it would dial {routed:?}"
+        );
+    }
+
+    /// Drive the wrapper's own `poll` until it yields nothing more, collecting what it emits.
+    /// Runs the reconnect timer and the lookup queue, which is where redials are scheduled.
+    fn drain_poll(behaviour: &mut BaseBehaviour) -> Vec<TToSwarm<BaseBehaviour>> {
+        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+        let mut events = vec![];
+        while let Poll::Ready(evs) = BehaviourWrapper::poll(behaviour, &mut cx) {
+            let before = events.len();
+            events.extend(evs);
+            if events.len() == before {
+                break;
+            }
+        }
+        events
+    }
+
+    fn dial_failure(peer: PeerId, error: &DialError) -> FromSwarm<'_> {
+        FromSwarm::DialFailure(DialFailure {
+            peer_id: Some(peer),
+            error,
+            connection_id: ConnectionId::new_unchecked(2),
+        })
+    }
+
+    fn dialed(addr: &Multiaddr) -> ConnectedPoint {
+        ConnectedPoint::Dialer {
+            address: addr.clone(),
+            role_override: Endpoint::Dialer,
+            port_use: PortUse::Reuse,
+        }
+    }
+
+    /// A registered worker we are connected to stops being reachable — its host drops off the
+    /// network, keeping the peer ID and losing the address.
+    ///
+    /// The reconnect path fires exactly once, on `ConnectionClosed`, and at that moment the
+    /// address cache still holds the now-dead address, so `find_and_dial` dials it instead of
+    /// looking the worker up. That dial fails, which empties the cache — and nothing schedules a
+    /// Kademlia lookup afterwards, because `reconnect_queue` is fed only by connection closures
+    /// and the whitelist sweep is suppressed while the registered set is unchanged. Every later
+    /// heartbeat request then dies with `NoAddresses` until unrelated DHT traffic happens to
+    /// repopulate the cache, which is the 15–100 minute stranding seen in production (NET-384).
+    #[tokio::test(start_paused = true)]
+    async fn looks_up_worker_whose_cached_address_stopped_working() {
+        let local = Keypair::generate_ed25519();
+        let remote = Keypair::generate_ed25519();
+        let peer = remote.public().to_peer_id();
+        let stale = addr(12208, peer);
+
+        let mut behaviour = test_behaviour(&local);
+        behaviour.maintain_worker_connections();
+        // Stand in for the on-chain registration: this is what makes the worker eligible for
+        // reconnection and lookups.
+        behaviour.on_nodes_update(NetworkNodes {
+            portals: HashSet::new(),
+            workers: HashSet::from([peer]),
+        });
+        // The address a previous DHT lookup found, cached so it can be dialed directly.
+        behaviour.inner.address_cache.put(peer, Some(stale.clone()));
+
+        let endpoint = dialed(&stale);
+        behaviour.on_connection_established(ConnectionEstablished {
+            peer_id: peer,
+            connection_id: ConnectionId::new_unchecked(1),
+            endpoint: &endpoint,
+            failed_addresses: &[],
+            other_established: 0,
+        });
+
+        // The worker drops off the network and the connection goes down.
+        behaviour.on_connection_closed(ConnectionClosed {
+            peer_id: peer,
+            connection_id: ConnectionId::new_unchecked(1),
+            endpoint: &endpoint,
+            cause: None,
+            remaining_established: 0,
+        });
+
+        // Let the reconnect cooldown elapse, so the queued redial is attempted.
+        tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
+        let redial = drain_poll(&mut behaviour);
+        assert!(
+            redial.iter().any(|ev| matches!(ev, ToSwarm::Dial { .. })),
+            "expected a redial after the cooldown, got {} event(s)",
+            redial.len()
+        );
+
+        // That redial goes to the dead address and fails, which empties the address cache.
+        let error = DialError::Transport(vec![(
+            stale.clone(),
+            TransportError::Other(std::io::Error::other("host unreachable")),
+        )]);
+        // `Wrapped` hands swarm events to the inner behaviours first and to the wrapper second
+        // (see `wrapped.rs`), so the cache has already evicted by the time `BaseBehaviour` sees
+        // the failure. Replicated here in that order.
+        behaviour.inner.address_cache.on_swarm_event(dial_failure(peer, &error));
+        behaviour.on_swarm_event(dial_failure(peer, &error));
+
+        // Guards against the test passing vacuously if eviction stops happening on dial failure.
+        assert!(
+            !behaviour.inner.address_cache.contains(&peer),
+            "dial failure no longer evicts; this test would assert nothing"
+        );
+
+        // We now know no address for a worker we are supposed to stay connected to. The only way
+        // back is a DHT lookup, so one has to be scheduled.
+        tokio::time::advance(behaviour.reconnect_cooldown * 2).await;
+        drain_poll(&mut behaviour);
+        assert!(
+            behaviour.ongoing_lookups.contains_left(&peer),
+            "no Kademlia lookup started after the cache was emptied: the worker stays undialable \
+             until unrelated DHT traffic supplies an address"
         );
     }
 }

--- a/crates/transport/src/behaviour/base.rs
+++ b/crates/transport/src/behaviour/base.rs
@@ -20,7 +20,7 @@ use libp2p::{
     swarm::{
         behaviour::ConnectionEstablished,
         dial_opts::{DialOpts, PeerCondition},
-        ConnectionClosed, FromSwarm, NetworkBehaviour, ToSwarm,
+        ConnectionClosed, DialError, DialFailure, FromSwarm, NetworkBehaviour, ToSwarm,
     },
     StreamProtocol,
 };
@@ -292,6 +292,7 @@ impl BehaviourWrapper for BaseBehaviour {
         match ev {
             FromSwarm::ConnectionEstablished(conn) => self.on_connection_established(conn),
             FromSwarm::ConnectionClosed(conn) => self.on_connection_closed(conn),
+            FromSwarm::DialFailure(failure) => self.on_dial_failure(failure),
             _ => None,
         }
     }
@@ -320,6 +321,12 @@ impl BehaviourWrapper for BaseBehaviour {
         // the timer waker, so it must run even when there's a pending event to emit. Skipping
         // it behind the early return below would let a cooldown entry expire without a
         // registered waker, deferring the redial until some unrelated event wakes the task.
+        // Known limitation: `reconnect_scheduled` is cleared here rather than when the dial is
+        // actually issued, so it de-duplicates against `reconnect_queue` but not against
+        // `pending_lookups`. A peer held back by the `max_concurrent_lookups` cap therefore
+        // collects one extra `pending_lookups` entry per dial failure, and that queue is
+        // unbounded. Harmless at the current worker counts, where the cap is not reached;
+        // tracking the dial through to its start would need more state than it is worth.
         while let Poll::Ready(Some(expired)) = self.reconnect_queue.poll_expired(cx) {
             let peer_id = expired.into_inner();
             self.reconnect_scheduled.remove(&peer_id);
@@ -385,6 +392,49 @@ impl BaseBehaviour {
             );
             self.reconnect_queue.insert(peer_id, self.reconnect_cooldown);
         }
+        None
+    }
+
+    /// A failed dial to a registered worker is the only signal that its cached address is dead:
+    /// `AddressCache` drops the entry on exactly these errors (`addr_cache.rs`), and until this
+    /// arm existed nothing re-armed afterwards, because a failed dial establishes no connection
+    /// and so produces no close event. The worker then stayed undialable until unrelated DHT
+    /// traffic happened to supply an address — the stranding in NET-384.
+    ///
+    /// `DialError::NoAddresses` is deliberately not covered. It also evicts, but it is the error
+    /// a fruitless lookup produces, so scheduling on it would let the recovery feed itself
+    /// indefinitely.
+    ///
+    /// Retries are unbounded: a worker that stays registered is one we are supposed to hold a
+    /// connection to, so it is worth looking up for as long as that holds. `reconnect_scheduled`
+    /// and the cooldown cap the cost at one lookup per peer per `reconnect_cooldown`, and the
+    /// registered set is what bounds the population.
+    ///
+    /// The queued dial goes through `find_and_dial`, so it uses the address cache if something
+    /// refilled it during the cooldown. That is the right call when the new address is fresher
+    /// than the failure — a concurrent lookup landing its result — and costs one extra cooldown
+    /// when it is Kademlia echoing back the address we just disproved, after which the next
+    /// failure re-arms. Unbounded retries are what make that merely slow instead of terminal.
+    fn on_dial_failure(&mut self, failure: DialFailure) -> Option<TToSwarm<Self>> {
+        let peer_id = failure.peer_id?;
+        if !matches!(failure.error, DialError::Transport(_) | DialError::WrongPeerId { .. }) {
+            return None;
+        }
+        if !self.maintain_worker_connections
+            || self.outbound_conn_exists(&peer_id)
+            || !self.registered_workers.contains(&peer_id)
+        {
+            return None;
+        }
+        // Skip if a reconnect is already pending, as in `on_connection_closed`.
+        if !self.reconnect_scheduled.insert(peer_id) {
+            return None;
+        }
+        log::debug!(
+            "Dial to worker {peer_id} failed, scheduling a lookup in {:?}",
+            self.reconnect_cooldown
+        );
+        self.reconnect_queue.insert(peer_id, self.reconnect_cooldown);
         None
     }
 
@@ -575,7 +625,7 @@ impl BaseBehaviour {
 mod tests {
     use libp2p::{
         core::{transport::PortUse, Endpoint},
-        swarm::{ConnectionId, DialError, DialFailure},
+        swarm::ConnectionId,
         Multiaddr, TransportError,
     };
     use sqd_contract_client::{DummyClient, DummyData};
@@ -733,6 +783,53 @@ mod tests {
         }
     }
 
+    fn transport_error(addr: &Multiaddr) -> DialError {
+        DialError::Transport(vec![(
+            addr.clone(),
+            TransportError::Other(std::io::Error::other("host unreachable")),
+        )])
+    }
+
+    /// Deliver a dial failure the way `Wrapped` does: inner behaviours first (so the address
+    /// cache evicts), then the wrapper (see `wrapped.rs`).
+    fn deliver_dial_failure(behaviour: &mut BaseBehaviour, peer: PeerId, error: &DialError) {
+        behaviour.inner.address_cache.on_swarm_event(dial_failure(peer, error));
+        behaviour.on_swarm_event(dial_failure(peer, error));
+    }
+
+    /// A registered worker whose connection has closed and whose cached address then failed.
+    /// Leaves the behaviour at the point where recovery has to happen.
+    fn stranded_worker(local: &Keypair, peer: PeerId, addr: &Multiaddr) -> BaseBehaviour {
+        let mut behaviour = test_behaviour(local);
+        behaviour.maintain_worker_connections();
+        behaviour.on_nodes_update(NetworkNodes {
+            portals: HashSet::new(),
+            workers: HashSet::from([peer]),
+        });
+        behaviour.inner.address_cache.put(peer, Some(addr.clone()));
+        // The whitelist sweep queues its own dial for a newly registered worker. Let it run, so
+        // the state left behind is a plain established connection rather than a half-drained
+        // sweep, and `reconnect_scheduled` reflects only what the close below schedules.
+        drain_poll(&mut behaviour);
+
+        let endpoint = dialed(addr);
+        behaviour.on_connection_established(ConnectionEstablished {
+            peer_id: peer,
+            connection_id: ConnectionId::new_unchecked(1),
+            endpoint: &endpoint,
+            failed_addresses: &[],
+            other_established: 0,
+        });
+        behaviour.on_connection_closed(ConnectionClosed {
+            peer_id: peer,
+            connection_id: ConnectionId::new_unchecked(1),
+            endpoint: &endpoint,
+            cause: None,
+            remaining_established: 0,
+        });
+        behaviour
+    }
+
     /// A registered worker we are connected to stops being reachable — its host drops off the
     /// network, keeping the peer ID and losing the address.
     ///
@@ -750,34 +847,8 @@ mod tests {
         let peer = remote.public().to_peer_id();
         let stale = addr(12208, peer);
 
-        let mut behaviour = test_behaviour(&local);
-        behaviour.maintain_worker_connections();
-        // Stand in for the on-chain registration: this is what makes the worker eligible for
-        // reconnection and lookups.
-        behaviour.on_nodes_update(NetworkNodes {
-            portals: HashSet::new(),
-            workers: HashSet::from([peer]),
-        });
-        // The address a previous DHT lookup found, cached so it can be dialed directly.
-        behaviour.inner.address_cache.put(peer, Some(stale.clone()));
-
-        let endpoint = dialed(&stale);
-        behaviour.on_connection_established(ConnectionEstablished {
-            peer_id: peer,
-            connection_id: ConnectionId::new_unchecked(1),
-            endpoint: &endpoint,
-            failed_addresses: &[],
-            other_established: 0,
-        });
-
-        // The worker drops off the network and the connection goes down.
-        behaviour.on_connection_closed(ConnectionClosed {
-            peer_id: peer,
-            connection_id: ConnectionId::new_unchecked(1),
-            endpoint: &endpoint,
-            cause: None,
-            remaining_established: 0,
-        });
+        // Registered on chain, connected on a cached address, then dropped off the network.
+        let mut behaviour = stranded_worker(&local, peer, &stale);
 
         // Let the reconnect cooldown elapse, so the queued redial is attempted.
         tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
@@ -789,15 +860,7 @@ mod tests {
         );
 
         // That redial goes to the dead address and fails, which empties the address cache.
-        let error = DialError::Transport(vec![(
-            stale.clone(),
-            TransportError::Other(std::io::Error::other("host unreachable")),
-        )]);
-        // `Wrapped` hands swarm events to the inner behaviours first and to the wrapper second
-        // (see `wrapped.rs`), so the cache has already evicted by the time `BaseBehaviour` sees
-        // the failure. Replicated here in that order.
-        behaviour.inner.address_cache.on_swarm_event(dial_failure(peer, &error));
-        behaviour.on_swarm_event(dial_failure(peer, &error));
+        deliver_dial_failure(&mut behaviour, peer, &transport_error(&stale));
 
         // Guards against the test passing vacuously if eviction stops happening on dial failure.
         assert!(
@@ -813,6 +876,155 @@ mod tests {
             behaviour.ongoing_lookups.contains_left(&peer),
             "no Kademlia lookup started after the cache was emptied: the worker stays undialable \
              until unrelated DHT traffic supplies an address"
+        );
+    }
+
+    /// If something refills the cache during the cooldown, the queued dial uses it rather than
+    /// looking up. When that address is Kademlia echoing back the one we just disproved, the
+    /// round is wasted — but the dial fails again and re-arms, so recovery costs an extra
+    /// cooldown instead of stranding. This is what lets the change carry no per-peer mode state.
+    #[tokio::test(start_paused = true)]
+    async fn a_cache_refilled_during_the_cooldown_costs_a_round_but_re_arms() {
+        let local = Keypair::generate_ed25519();
+        let peer = Keypair::generate_ed25519().public().to_peer_id();
+        let stale = addr(12208, peer);
+
+        let mut behaviour = stranded_worker(&local, peer, &stale);
+        tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
+        drain_poll(&mut behaviour);
+        deliver_dial_failure(&mut behaviour, peer, &transport_error(&stale));
+
+        // Kademlia echoes the dead address back while the reconnect waits out its cooldown.
+        behaviour.on_kademlia_event(kad::Event::RoutablePeer {
+            peer,
+            address: stale.clone(),
+        });
+        assert!(
+            behaviour.inner.address_cache.contains(&peer),
+            "kademlia did not repopulate the cache; this test would assert nothing"
+        );
+
+        // The wasted round: the cached address is dialed rather than looked up.
+        tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
+        let events = drain_poll(&mut behaviour);
+        assert!(
+            !behaviour.ongoing_lookups.contains_left(&peer),
+            "expected the refilled cache to be dialed, not bypassed"
+        );
+        assert!(
+            events.iter().any(|ev| matches!(ev, ToSwarm::Dial { .. })),
+            "expected a dial to the cached address"
+        );
+
+        // It fails again, and that re-arms — which is what keeps the round merely wasted.
+        deliver_dial_failure(&mut behaviour, peer, &transport_error(&stale));
+        tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
+        drain_poll(&mut behaviour);
+        assert!(
+            behaviour.ongoing_lookups.contains_left(&peer),
+            "recovery stalled after a wasted round instead of looking the worker up"
+        );
+    }
+
+    /// The `outbound_conn_exists` gate: a dial can fail while another connection to the same
+    /// worker is up, and chasing a peer we are already connected to is pure waste.
+    #[tokio::test(start_paused = true)]
+    async fn dial_failure_schedules_nothing_while_a_connection_is_up() {
+        let local = Keypair::generate_ed25519();
+        let peer = Keypair::generate_ed25519().public().to_peer_id();
+        let addr = addr(12208, peer);
+
+        let mut behaviour = stranded_worker(&local, peer, &addr);
+        // Drain the reconnect the close queued, so it can't be mistaken for a new one.
+        tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
+        drain_poll(&mut behaviour);
+        assert!(!behaviour.reconnect_scheduled.contains(&peer), "reconnect did not drain");
+
+        let endpoint = dialed(&addr);
+        behaviour.on_connection_established(ConnectionEstablished {
+            peer_id: peer,
+            connection_id: ConnectionId::new_unchecked(3),
+            endpoint: &endpoint,
+            failed_addresses: &[],
+            other_established: 0,
+        });
+
+        // A second, redundant dial fails while that connection is still up.
+        deliver_dial_failure(&mut behaviour, peer, &transport_error(&addr));
+        assert!(
+            !behaviour.reconnect_scheduled.contains(&peer),
+            "scheduled a reconnect for a worker we are already connected to"
+        );
+    }
+
+    /// Dropping off the registered set is what stops the retries.
+    #[tokio::test(start_paused = true)]
+    async fn stops_retrying_once_the_worker_leaves_the_registered_set() {
+        let local = Keypair::generate_ed25519();
+        let peer = Keypair::generate_ed25519().public().to_peer_id();
+        let stale = addr(12208, peer);
+
+        let mut behaviour = stranded_worker(&local, peer, &stale);
+        tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
+        drain_poll(&mut behaviour);
+
+        behaviour.on_nodes_update(NetworkNodes {
+            portals: HashSet::new(),
+            workers: HashSet::new(),
+        });
+        deliver_dial_failure(&mut behaviour, peer, &transport_error(&stale));
+        assert!(
+            !behaviour.reconnect_scheduled.contains(&peer),
+            "kept chasing a worker that is no longer registered"
+        );
+    }
+
+    /// `NoAddresses` is what a fruitless lookup produces, so scheduling on it would let recovery
+    /// feed itself. Out of scope until per-peer backoff exists.
+    #[tokio::test(start_paused = true)]
+    async fn no_addresses_failure_does_not_schedule_a_lookup() {
+        let local = Keypair::generate_ed25519();
+        let peer = Keypair::generate_ed25519().public().to_peer_id();
+        let stale = addr(12208, peer);
+
+        let mut behaviour = stranded_worker(&local, peer, &stale);
+        tokio::time::advance(behaviour.reconnect_cooldown + Duration::from_secs(1)).await;
+        drain_poll(&mut behaviour);
+
+        deliver_dial_failure(&mut behaviour, peer, &DialError::NoAddresses);
+        assert!(
+            !behaviour.reconnect_scheduled.contains(&peer),
+            "NoAddresses scheduled a lookup, which lets an empty lookup retry itself"
+        );
+    }
+
+    /// Only actors in `maintain_worker_connections` mode chase reconnections, and only for peers
+    /// the contracts list as registered.
+    #[tokio::test(start_paused = true)]
+    async fn dial_failure_schedules_nothing_outside_maintained_workers() {
+        let local = Keypair::generate_ed25519();
+        let peer = Keypair::generate_ed25519().public().to_peer_id();
+        let stranger = Keypair::generate_ed25519().public().to_peer_id();
+        let stale = addr(12208, peer);
+
+        // Registered, but this actor does not maintain worker connections.
+        let mut passive = test_behaviour(&local);
+        passive.on_nodes_update(NetworkNodes {
+            portals: HashSet::new(),
+            workers: HashSet::from([peer]),
+        });
+        deliver_dial_failure(&mut passive, peer, &transport_error(&stale));
+        assert!(
+            !passive.reconnect_scheduled.contains(&peer),
+            "scheduled a reconnect without maintain_worker_connections"
+        );
+
+        // Maintains connections, but the peer is not a registered worker.
+        let mut active = stranded_worker(&local, peer, &stale);
+        deliver_dial_failure(&mut active, stranger, &transport_error(&addr(12208, stranger)));
+        assert!(
+            !active.reconnect_scheduled.contains(&stranger),
+            "scheduled a reconnect for an unregistered peer"
         );
     }
 }

--- a/crates/transport/src/util.rs
+++ b/crates/transport/src/util.rs
@@ -61,6 +61,15 @@ pub fn addr_is_reachable(addr: &Multiaddr) -> bool {
     }
 }
 
+/// `addr_is_reachable` reads `PRIVATE_NETWORK` from the environment on every call, and Rust runs
+/// the tests of a binary as threads in one process — so a test that sets the variable changes what
+/// every concurrently running test sees. Any test that reads or writes it must hold this lock.
+#[cfg(test)]
+pub(crate) fn private_network_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -68,6 +77,10 @@ mod test {
 
     #[test]
     fn test_addr_is_reachable() {
+        let _guard = private_network_env_lock();
+        // Start from a known state: a developer's shell, or a previous test, may have set it.
+        std::env::remove_var("PRIVATE_NETWORK");
+
         assert!(!addr_is_reachable(&multiaddr!(Ip4([127, 0, 0, 1]), Tcp(12345u16))));
         assert!(!addr_is_reachable(&multiaddr!(Ip4([169, 254, 0, 1]), Tcp(12345u16))));
         assert!(!addr_is_reachable(&multiaddr!(Ip4([192, 168, 0, 1]), Tcp(12345u16))));
@@ -84,5 +97,9 @@ mod test {
         assert!(addr_is_reachable(&multiaddr!(Ip4([192, 168, 0, 1]), Tcp(12345u16))));
         assert!(addr_is_reachable(&multiaddr!(Ip4([10, 0, 0, 1]), Tcp(12345u16))));
         assert!(addr_is_reachable(&multiaddr!(Ip4([172, 16, 0, 1]), Tcp(12345u16))));
+
+        // Leave the process as we found it, so tests that expect private addresses to be
+        // unreachable still see that.
+        std::env::remove_var("PRIVATE_NETWORK");
     }
 }

--- a/crates/transport/src/util.rs
+++ b/crates/transport/src/util.rs
@@ -67,7 +67,7 @@ pub fn addr_is_reachable(addr: &Multiaddr) -> bool {
 #[cfg(test)]
 pub(crate) fn private_network_env_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### The current approach

After #199 the clients, e.g. pings collector, are trying to always keep connections to all workers open. This is a separate loop from actually sending the requests to them.
If a request is attempted and there is neither an existing connection nor known addresses of the peer, it just fails immediately. It **doesn't** trigger new Kademlia lookups because it assumes that the background loop already made the best effort to have that connection open.

The background loop works like this:
- We schedule DHT lookups for all the known workers, putting them in the queue.
- Every lookup for a peer finds many other peer+address pairs along the way. Those addresses get saved to the `AddressCache`.
- On the next lookup request from the queue, we check the address cache first and only start a Kademlia query if the peer is not yet cached.

As a result
- Some workers are kept connected. On connection close the `find_and_dial` is rescheduled and the connection gets re-established.
- Some workers don't have addresses in DHT and fall out of the loop. (They are usually dead forever and don't return to the network. But if they do, they won't be picked up until the pings collector restarts, which is a separate issue.)

### The issue

Every time the worker changes the address, it drops out of the healthy loop. At least until a happy coincidence returns it to the healthy loop, which usually takes >1h.

Why:
1. The connection to the worker closes, and a lookup is scheduled.
2. The address cache still holds the peer's addresses. A connection closing doesn't evict anything — only a dial failure does. So the cached address is dialed, but no Kad query is issued.
3. That dial uses the stale cached addresses and fails. Now `AddressCache::on_dial_failure` evicts the entry. But nothing re-schedules the address lookup.
4. Effectively that worker stays disconnected and all requests to it fail with "`no addresses for peer`".

### The fix

The lookups are now scheduled on **dial failures** caused by unreachable addresses.

On the healthy loop, a stale address triggers a Kad query to get the worker reconnected if there is a reachable address in DHT.
Even if that peer is not reachable yet, it will keep retrying lookups every 30s because Kademlia keeps the last known address and won't evict it. Only if the peer completely drops out of Kademlia (`NoAddresses` path), it gets dropped from the reconnect loop.