### PR TITLE
feat(assignments): Add assignment_type to network state, to guide consumers which one should be used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "sqd-assignments"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/assignments/Cargo.toml
+++ b/crates/assignments/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqd-assignments"
 license = "AGPL-3.0-or-later"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [features]

--- a/crates/assignments/src/common.rs
+++ b/crates/assignments/src/common.rs
@@ -23,6 +23,16 @@ pub struct NetworkAssignment {
     pub effective_from: u64,
 }
 
+/// Where a split assignment blob lives. Replaces [`NetworkAssignment`] for the split blobs: one
+/// required url plus the format version of what is at it, rather than a field per format.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct NetworkAssignmentV2 {
+    pub id: String,
+    pub fb_url: String,
+    /// Format of the blob at `fb_url`, not of this struct. Free-form until the format settles.
+    pub version: String,
+}
+
 /// Where to fetch the schema content that assignments only reference by id — a worker chunk's
 /// `write_schema_id`, a portal dataset's `read_schema_id`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -32,28 +42,113 @@ pub struct SchemaBundle {
     pub url: String,
 }
 
+/// Which of a state's assignments a consumer should read. A migrating state publishes both shapes
+/// at once, so which blobs are present says nothing about which are authoritative.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AssignmentType {
+    /// Also what an absent `assignment_type` means: such a state predates the split.
+    #[default]
+    Legacy,
+    Split,
+}
+
+impl std::fmt::Display for AssignmentType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Legacy => "legacy",
+            Self::Split => "split",
+        })
+    }
+}
+
 /// The published network state.
 ///
 /// Migrating to split assignments walks a state through three shapes: `assignment` alone, then
-/// `assignment` alongside `worker_assignment`/`portal_assignment` while consumers switch over,
-/// then the split pair alone. Every field but `network` is therefore optional — which shapes are
-/// actually valid is the publisher's call, not this type's.
+/// `assignment` alongside the split blobs while consumers switch over, then the split blobs
+/// alone. The middle shape serves both generations at once, so every blob is optional and
+/// publishing both sets is expected — [`Self::assignment_type`] is what picks between them.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NetworkState {
     pub network: String,
 
-    /// The combined assignment served identically to workers and portals. Optional: a network
-    /// that has finished migrating stops publishing it, leaving the split blobs below as the
-    /// only source.
+    /// Which of the assignments below to read. Absent means [`AssignmentType::Legacy`], so states
+    /// published before this field existed still read correctly.
+    #[serde(default)]
+    pub assignment_type: AssignmentType,
+
+    /// The combined assignment, served identically to workers and portals. Stays published
+    /// alongside the split blobs until nothing reads it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assignment: Option<NetworkAssignment>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub worker_assignment: Option<NetworkAssignment>,
+    pub worker_assignment: Option<NetworkAssignmentV2>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub portal_assignment: Option<NetworkAssignment>,
+    pub portal_assignment: Option<NetworkAssignmentV2>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schema_bundle: Option<SchemaBundle>,
+}
+
+/// The assignments an [`AssignmentType`] names, taken out of a [`NetworkState`].
+#[derive(Debug)]
+pub enum ResolvedAssignments {
+    Legacy(NetworkAssignment),
+    Split {
+        worker: NetworkAssignmentV2,
+        portal: NetworkAssignmentV2,
+        schema_bundle: SchemaBundle,
+    },
+}
+
+impl NetworkState {
+    /// Takes the assignments named by `assignment_type`, falling back to [`Self::assignment_type`]
+    /// when it is `None`. The override lets a consumer pin a shape regardless of what the state
+    /// says, which is how one gets switched over ahead of — or held back during — the migration.
+    ///
+    /// Consuming: what it leaves behind belongs to consumers on the other side of the migration.
+    ///
+    /// # Errors
+    ///
+    /// [`InvalidNetworkState`] if the state does not publish the assignments named.
+    pub fn resolve(
+        self,
+        assignment_type: Option<AssignmentType>,
+    ) -> Result<ResolvedAssignments, InvalidNetworkState> {
+        let assignment_type = assignment_type.unwrap_or(self.assignment_type);
+        let missing = |missing| InvalidNetworkState {
+            assignment_type,
+            missing,
+        };
+
+        match assignment_type {
+            AssignmentType::Legacy => self
+                .assignment
+                .map(ResolvedAssignments::Legacy)
+                .ok_or_else(|| missing("assignment")),
+            AssignmentType::Split => {
+                match (self.worker_assignment, self.portal_assignment, self.schema_bundle) {
+                    (Some(worker), Some(portal), Some(schema_bundle)) => {
+                        Ok(ResolvedAssignments::Split {
+                            worker,
+                            portal,
+                            schema_bundle,
+                        })
+                    }
+                    (None, ..) => Err(missing("worker_assignment")),
+                    (_, None, _) => Err(missing("portal_assignment")),
+                    _ => Err(missing("schema_bundle")),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error("assignment_type is \"{assignment_type}\" but {missing} is not published")]
+pub struct InvalidNetworkState {
+    pub assignment_type: AssignmentType,
+    pub missing: &'static str,
 }

--- a/crates/assignments/src/lib.rs
+++ b/crates/assignments/src/lib.rs
@@ -52,7 +52,10 @@ mod reader;
 #[cfg(feature = "builder")]
 mod signatures;
 
-pub use common::{NetworkAssignment, NetworkState, SchemaBundle, WorkerStatus};
+pub use common::{
+    AssignmentType, InvalidNetworkState, NetworkAssignment, NetworkAssignmentV2, NetworkState,
+    ResolvedAssignments, SchemaBundle, WorkerStatus,
+};
 
 #[cfg(feature = "builder")]
 pub use builder::AssignmentBuilder;

--- a/crates/assignments/tests/network_state.rs
+++ b/crates/assignments/tests/network_state.rs
@@ -1,4 +1,6 @@
-use sqd_assignments::{NetworkState, SchemaBundle};
+use sqd_assignments::{
+    AssignmentType, NetworkAssignmentV2, NetworkState, ResolvedAssignments, SchemaBundle,
+};
 
 const LEGACY_STATE: &str = r#"{
   "network": "testnet",
@@ -14,15 +16,16 @@ const LEGACY_STATE: &str = r#"{
 /// The migration's end state: the legacy blob is gone and the split pair is the only source.
 const SPLIT_ONLY_STATE: &str = r#"{
   "network": "testnet",
+  "assignment_type": "split",
   "worker_assignment": {
-    "fb_url_v1": "https://example.test/worker.fb.1.gz",
+    "fb_url": "https://example.test/worker.fb.1.gz",
     "id": "worker",
-    "effective_from": 1781000000
+    "version": "1"
   },
   "portal_assignment": {
-    "fb_url_v1": "https://example.test/portal.fb.1.gz",
+    "fb_url": "https://example.test/portal.fb.1.gz",
     "id": "portal",
-    "effective_from": 1781000000
+    "version": "1"
   },
   "schema_bundle": {
     "hash": "a1b2c3",
@@ -66,11 +69,14 @@ fn deprecated_assignment_urls_default_and_skip_when_absent() {
     assert!(serialized["assignment"].get("fb_url").is_none());
 }
 
+/// The middle of the migration: both shapes published at once, `assignment_type` picking between
+/// them so consumers that predate the split keep reading `assignment`.
 #[test]
 fn split_network_state_deserializes() {
     let state: NetworkState = serde_json::from_str(
         r#"{
           "network": "testnet",
+          "assignment_type": "split",
           "assignment": {
             "url": "",
             "fb_url": "https://example.test/legacy.fb.0.gz",
@@ -79,18 +85,14 @@ fn split_network_state_deserializes() {
             "effective_from": 1781000000
           },
           "worker_assignment": {
-            "url": "",
-            "fb_url": "https://example.test/worker.fb.0.gz",
-            "fb_url_v1": "https://example.test/worker.fb.1.gz",
+            "fb_url": "https://example.test/worker.fb.1.gz",
             "id": "worker",
-            "effective_from": 1781000000
+            "version": "1"
           },
           "portal_assignment": {
-            "url": "",
-            "fb_url": "https://example.test/portal.fb.0.gz",
-            "fb_url_v1": "https://example.test/portal.fb.1.gz",
+            "fb_url": "https://example.test/portal.fb.1.gz",
             "id": "portal",
-            "effective_from": 1781000000
+            "version": "1"
           },
           "schema_bundle": {
             "hash": "a1b2c3",
@@ -100,9 +102,17 @@ fn split_network_state_deserializes() {
     )
     .unwrap();
 
-    assert_eq!(state.assignment.unwrap().id, "legacy");
-    assert_eq!(state.worker_assignment.unwrap().id, "worker");
-    assert_eq!(state.portal_assignment.unwrap().id, "portal");
+    assert_eq!(state.assignment_type, AssignmentType::Split);
+    assert_eq!(state.assignment.as_ref().unwrap().id, "legacy");
+    assert_eq!(
+        state.worker_assignment.clone().unwrap(),
+        NetworkAssignmentV2 {
+            id: "worker".to_owned(),
+            fb_url: "https://example.test/worker.fb.1.gz".to_owned(),
+            version: "1".to_owned(),
+        }
+    );
+    assert_eq!(state.portal_assignment.as_ref().unwrap().id, "portal");
 
     assert_eq!(
         state.schema_bundle,
@@ -119,13 +129,12 @@ fn split_only_network_state_deserializes() {
 
     assert!(state.assignment.is_none(), "a migrated network publishes no legacy assignment");
     assert_eq!(state.worker_assignment.unwrap().id, "worker");
-    assert_eq!(state.portal_assignment.unwrap().id, "portal");
+    assert_eq!(state.portal_assignment.as_ref().unwrap().id, "portal");
     assert!(state.schema_bundle.is_some());
 }
 
-/// Nothing rejects a state carrying no assignment at all: this type models the wire format, not
-/// the publisher's rules about which combinations are meaningful. If such a state should be an
-/// error, the check belongs in a `#[serde(try_from = "...")]` on `NetworkState`.
+/// Parsing still models the wire format rather than the publisher's rules; `validate` is what
+/// refuses a state whose declared type has nothing behind it.
 #[test]
 fn network_state_without_any_assignment_is_accepted() {
     let state: NetworkState = serde_json::from_str(r#"{"network": "testnet"}"#).unwrap();
@@ -134,6 +143,8 @@ fn network_state_without_any_assignment_is_accepted() {
     assert!(state.worker_assignment.is_none());
     assert!(state.portal_assignment.is_none());
     assert!(state.schema_bundle.is_none());
+
+    assert_eq!(state.resolve(None).unwrap_err().missing, "assignment");
 }
 
 #[test]
@@ -200,4 +211,83 @@ fn absent_legacy_assignment_stays_omitted_after_json_round_trip() {
     assert!(value.get("worker_assignment").is_some());
     assert!(value.get("portal_assignment").is_some());
     assert!(value.get("schema_bundle").is_some());
+}
+
+const LEGACY: &str = r#""assignment": {"fb_url_v1": "l", "id": "l", "effective_from": 1}"#;
+const WORKER: &str = r#""worker_assignment": {"fb_url": "w", "id": "w", "version": "1"}"#;
+const PORTAL: &str = r#""portal_assignment": {"fb_url": "p", "id": "p", "version": "1"}"#;
+const BUNDLE: &str = r#""schema_bundle": {"hash": "h", "url": "u"}"#;
+
+fn state(assignment_type: &str, fields: &[&str]) -> NetworkState {
+    let json = format!(
+        r#"{{"network": "t", "assignment_type": "{assignment_type}", {}}}"#,
+        fields.join(", ")
+    );
+    serde_json::from_str(&json).unwrap()
+}
+
+#[test]
+fn absent_assignment_type_means_legacy() {
+    let state: NetworkState = serde_json::from_str(LEGACY_STATE).unwrap();
+
+    assert_eq!(state.assignment_type, AssignmentType::Legacy);
+    assert_eq!(serde_json::to_value(&state).unwrap()["assignment_type"], "legacy");
+    assert!(state.resolve(None).is_ok());
+}
+
+#[test]
+fn resolve_requires_the_blobs_the_assignment_type_names() {
+    for (assignment_type, fields, missing) in [
+        ("legacy", vec![WORKER, PORTAL, BUNDLE], Some("assignment")),
+        ("split", vec![PORTAL, BUNDLE], Some("worker_assignment")),
+        ("split", vec![WORKER, BUNDLE], Some("portal_assignment")),
+        ("split", vec![WORKER, PORTAL], Some("schema_bundle")),
+        ("legacy", vec![LEGACY, WORKER], None),
+        ("split", vec![LEGACY, WORKER, PORTAL, BUNDLE], None),
+    ] {
+        let resolved = state(assignment_type, &fields).resolve(None);
+
+        assert_eq!(resolved.err().map(|e| e.missing), missing, "{fields:?}");
+    }
+}
+
+#[test]
+fn malformed_assignment_types_and_v2_blobs_are_rejected() {
+    let bad_type = [r#""LEGACY""#, r#""combined""#, "null", "0"];
+    for value in bad_type {
+        let json = format!(r#"{{"network": "t", "assignment_type": {value}}}"#);
+        serde_json::from_str::<NetworkState>(&json).expect_err(&format!("bad type: {value}"));
+    }
+
+    // A url is required and non-null, unlike the optional urls on the legacy assignment.
+    for blob in [
+        r#"{"id": "w", "version": "1"}"#,
+        r#"{"id": "w", "fb_url": null, "version": "1"}"#,
+        r#"{"id": "w", "fb_url": "w"}"#,
+    ] {
+        let json = format!(r#"{{"network": "t", "worker_assignment": {blob}}}"#);
+        serde_json::from_str::<NetworkState>(&json).expect_err(&format!("bad blob: {blob}"));
+    }
+}
+
+/// The override wins over the state's own type, so a consumer can be switched over ahead of the
+/// network — or held back — without the publisher changing anything.
+#[test]
+fn resolve_prefers_the_override_over_the_states_own_type() {
+    let joint = || state("legacy", &[LEGACY, WORKER, PORTAL, BUNDLE]);
+
+    assert!(
+        matches!(joint().resolve(None).unwrap(), ResolvedAssignments::Legacy(a) if a.id == "l")
+    );
+    assert!(matches!(
+        joint().resolve(Some(AssignmentType::Split)).unwrap(),
+        ResolvedAssignments::Split { worker, .. } if worker.id == "w"
+    ));
+
+    // An override still has to be backed by published blobs, and the error names the override.
+    let error = state("split", &[WORKER, PORTAL, BUNDLE])
+        .resolve(Some(AssignmentType::Legacy))
+        .unwrap_err();
+    assert_eq!(error.assignment_type, AssignmentType::Legacy);
+    assert_eq!(error.missing, "assignment");
 }


### PR DESCRIPTION
## What is this PR about?

Once workers and portals support both combined and split assignments, choosing between them should be an explicit state decision rather than an artifact of what each component happens to have deployed.

This change publishes assignment_type, allowing us to switch modes—or roll back—by updating state instead of redeploying. resolve() also accepts an override so an individual consumer can be pinned to a specific assignment type. If assignment_type is absent, behavior remains unchanged and existing states continue to use the legacy path.

For split assignments, blobs now use NetworkAssignmentV2. The new format removes the unused effective_from field and replaces the url / fb_url / fb_url_v1 variants with a single url plus an explicit version. Since split mode is not live yet, this is a backwards-compatible cleanup with no migration cost.